### PR TITLE
FilesOs API proposal to implement `Files` operations 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,9 +29,9 @@ lazy val core = crossProject(JVMPlatform, JSPlatform, NativePlatform)
       "co.fs2"        %% "fs2-io"         % "3.10.2",
       "co.fs2"        %% "fs2-scodec"     % "3.10.2",
       "org.scodec"    %% "scodec-bits"    % "1.2.0",
-      "org.scodec"    %% "scodec-core"    % (if (scalaVersion.value.startsWith("2."))
-                                            "1.11.10"
-                                          else "2.3.0"),
+      "org.scodec" %% "scodec-core" % (if (scalaVersion.value.startsWith("2."))
+                                         "1.11.10"
+                                       else "2.3.0"),
       // Testing
       "com.disneystreaming" %% "weaver-cats"       % "0.8.4" % Test,
       "com.disneystreaming" %% "weaver-scalacheck" % "0.8.4" % Test

--- a/build.sbt
+++ b/build.sbt
@@ -22,12 +22,19 @@ lazy val core = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .settings(
     name := "shellfish",
     libraryDependencies ++= List(
-      "org.typelevel"  %% "cats-core"         % "2.12.0",
-      "org.typelevel"  %% "alleycats-core"    % "2.12.0",
-      "org.typelevel"  %% "cats-effect"       % "3.5.4",
-      "co.fs2"         %% "fs2-core"          % "3.10.2",
-      "co.fs2"         %% "fs2-io"            % "3.10.2",
-      "org.typelevel" %%% "munit-cats-effect" % "2.0.0" % Test
+      "org.typelevel" %% "cats-core"      % "2.12.0",
+      "org.typelevel" %% "alleycats-core" % "2.12.0",
+      "org.typelevel" %% "cats-effect"    % "3.5.4",
+      "co.fs2"        %% "fs2-core"       % "3.10.2",
+      "co.fs2"        %% "fs2-io"         % "3.10.2",
+      "co.fs2"        %% "fs2-scodec"     % "3.10.2",
+      "org.scodec"    %% "scodec-bits"    % "1.2.0",
+      "org.scodec"    %% "scodec-core"    % (if (scalaVersion.value.startsWith("2."))
+                                            "1.11.10"
+                                          else "2.3.0"),
+      // Testing
+      "com.disneystreaming" %% "weaver-cats"       % "0.8.4" % Test,
+      "com.disneystreaming" %% "weaver-scalacheck" % "0.8.4" % Test
     )
   )
 

--- a/core/src/main/scala/io/chrisdavenport/shellfish/FilesOs.scala
+++ b/core/src/main/scala/io/chrisdavenport/shellfish/FilesOs.scala
@@ -79,7 +79,7 @@ object FilesOs {
    *   The codec that translates the file contents into the type `A`
    * @return
    *   The file loaded in memory as a type `A`
-   * @throws Exception
+   * @throws java.lang.Exception
    *   if the file cannot be read or the contents cannot be parsed into the type
    *   `A`
    */

--- a/core/src/main/scala/io/chrisdavenport/shellfish/FilesOs.scala
+++ b/core/src/main/scala/io/chrisdavenport/shellfish/FilesOs.scala
@@ -21,19 +21,22 @@
 
 package io.chrisdavenport.shellfish
 
-import cats.effect.IO
+import cats.syntax.all.*
+import cats.effect.{IO, Resource}
 
 import fs2.{Stream, Chunk}
-import fs2.io.file.{Files, Path, Flags}
+import fs2.io.file.*
 
 import scodec.Codec
 import scodec.bits.ByteVector
+
+import scala.concurrent.duration.FiniteDuration
 
 import java.nio.charset.Charset
 
 object FilesOs {
 
-  val files: Files[IO] = Files[IO]
+  private val files: Files[IO] = Files[IO]
 
   // Read operations:
 
@@ -52,14 +55,14 @@ object FilesOs {
    * Reads the contents of the file at the path using the provided charset.
    * Returns it as a String loaded in memory.
    *
-   * @param charset
-   *   The charset to use to decode the file
    * @param path
    *   The path to read from
+   * @param charset
+   *   The charset to use to decode the file
    * @return
    *   The file loaded in memory as a String
    */
-  def readWithCharset(charset: Charset)(path: Path): IO[String] =
+  def readWithCharset(path: Path, charset: Charset): IO[String] =
     files
       .readAll(path)
       .through(fs2.text.decodeWithCharset(charset))
@@ -125,11 +128,36 @@ object FilesOs {
    * @param contents
    *   The contents to write to the file
    */
-  def write(path: Path)(contents: String): IO[Unit] =
+  def write(path: Path, contents: String): IO[Unit] =
     Stream
       .emit(contents)
       .covary[IO]
       .through(files.writeUtf8(path))
+      .compile
+      .drain
+
+  /**
+   * This function overwites the contents of the file at the path using the
+   * provided charset with the contents provided in form of a entire string
+   * loaded in memory.
+   *
+   * @param path
+   *   The path to write to
+   * @param contents
+   *   The contents to write to the file
+   * @param charset
+   *   The charset to use to encode the file
+   */
+  def writeWithCharset(
+      path: Path,
+      contents: String,
+      charset: Charset
+  ): IO[Unit] =
+    Stream
+      .emit(contents)
+      .covary[IO]
+      .through(fs2.text.encode(charset))
+      .through(files.writeAll(path))
       .compile
       .drain
 
@@ -142,7 +170,7 @@ object FilesOs {
    * @param contents
    *   The contents to write to the file
    */
-  def writeBytes(path: Path)(contents: ByteVector): IO[Unit] =
+  def writeBytes(path: Path, contents: ByteVector): IO[Unit] =
     Stream
       .chunk(Chunk.byteVector(contents))
       .covary[IO]
@@ -160,7 +188,7 @@ object FilesOs {
    * @param contents
    *   The contents to write to the file
    */
-  def writeLines(path: Path)(contents: Seq[String]): IO[Unit] =
+  def writeLines(path: Path, contents: Seq[String]): IO[Unit] =
     Stream
       .emits(contents)
       .covary[IO]
@@ -182,23 +210,49 @@ object FilesOs {
    * @param Codec[A]
    *   The codec that translates the type A into a ByteVector
    */
-  def writeAs[A: Codec](path: Path)(contents: A): IO[Unit] =
-    writeBytes(path)(Codec[A].encode(contents).require.bytes)
+  def writeAs[A: Codec](path: Path, contents: A): IO[Unit] =
+    writeBytes(path, Codec[A].encode(contents).require.bytes)
 
   /**
    * Similar to `write`, but appends to the file instead of overwriting it.
-   * Saves the content at the end of the file in form of a String.
+   * Saves the content at the end of the file in form of a String using UTF-8
+   * encoding.
    *
    * @param path
    *   The path to write to
    * @param contents
    *   The contents to write to the file
    */
-  def append(path: Path)(contents: String): IO[Unit] =
+  def append(path: Path, contents: String): IO[Unit] =
     Stream
       .emit(contents)
       .covary[IO]
       .through(files.writeUtf8(path, Flags.Append))
+      .compile
+      .drain
+
+  /**
+   * Similar to `write`, but appends to the file instead of overwriting it.
+   * Saves the content at the end of the file in form of a String using the
+   * provided charset.
+   *
+   * @param path
+   *   The path to write to
+   * @param contents
+   *   The contents to write to the file
+   * @param charset
+   *   The charset to use to encode the contents
+   */
+  def appendWithCharset(
+      path: Path,
+      contents: String,
+      charset: Charset
+  ): IO[Unit] =
+    Stream
+      .emit(contents)
+      .covary[IO]
+      .through(fs2.text.encode(charset))
+      .through(files.writeAll(path, Flags.Append))
       .compile
       .drain
 
@@ -211,7 +265,7 @@ object FilesOs {
    * @param contents
    *   The contents to write to the file
    */
-  def appendBytes(path: Path)(contents: ByteVector): IO[Unit] =
+  def appendBytes(path: Path, contents: ByteVector): IO[Unit] =
     Stream
       .chunk(Chunk.byteVector(contents))
       .covary[IO]
@@ -229,7 +283,7 @@ object FilesOs {
    * @param contents
    *   The contents to write to the file
    */
-  def appendLines(path: Path)(contents: Seq[String]): IO[Unit] =
+  def appendLines(path: Path, contents: Seq[String]): IO[Unit] =
     Stream
       .emits(contents)
       .covary[IO]
@@ -248,8 +302,8 @@ object FilesOs {
    * @param contents
    *   The contents to write to the file
    */
-  def appendLine(path: Path)(contents: String): IO[Unit] =
-    appendLines(path)(List(contents))
+  def appendLine(path: Path, contents: String): IO[Unit] =
+    append(path, s"\n$contents")
 
   /**
    * Similar to `write`, but appends to the file instead of overwriting it.
@@ -264,6 +318,448 @@ object FilesOs {
    * @param Codec[A]
    *   The codec that translates the type A into a ByteVector
    */
-  def appendAs[A: Codec](path: Path)(contents: A): IO[Unit] =
-    appendBytes(path)(Codec[A].encode(contents).require.bytes)
+  def appendAs[A: Codec](path: Path, contents: A): IO[Unit] =
+    appendBytes(path, Codec[A].encode(contents).require.bytes)
+
+  // Files operations:
+
+  /**
+   * Copies the source to the target, failing if source does not exist or the
+   * target already exists. To replace the existing instead, use `copy(source,
+   * target, CopyFlags(CopyFlag.ReplaceExisting))`.
+   */
+  def copy(source: Path, target: Path): IO[Unit] =
+    copy(source, target, CopyFlags.empty)
+
+  /**
+   * Copies the source to the target, following any directives supplied in the
+   * flags. By default, an error occurs if the target already exists, though
+   * this can be overriden via CopyFlag.ReplaceExisting.
+   */
+  def copy(source: Path, target: Path, flags: CopyFlags): IO[Unit] =
+    files.copy(source, target, flags)
+
+  /**
+   * Creates the specified directory with the permissions of "rwxrwxr-x" by
+   * default. Fails if the parent path does not already exist.
+   */
+  def createDirectory(path: Path): IO[Unit] = files.createDirectories(path)
+
+  /**
+   * Creates the specified directory with the specified permissions. Fails if
+   * the parent path does not already exist.
+   */
+  def createDirectory(path: Path, permissions: Permissions): IO[Unit] =
+    files.createDirectories(path, permissions.some)
+
+  /**
+   * Creates the specified directory and any non-existant parent directories.
+   */
+  def createDirectories(path: Path): IO[Unit] = files.createDirectories(path)
+
+  /**
+   * Creates the specified directory and any parent directories, using the
+   * supplied permissions for any directories that get created as a result of
+   * this operation. For example if `/a` exists and
+   * `createDirectories(Path("/a/b/c"), p)` is called, `/a/b` and `/a/b/c` are
+   * created with permissions set to `p` on each (and the permissions of `/a`
+   * remain unmodified).
+   */
+  def createDirectories(path: Path, permissions: Permissions): IO[Unit] =
+    files.createDirectories(path, permissions.some)
+
+  /**
+   * Creates the specified file with the permissions of "rw-rw-r--" by default.
+   * Fails if the parent path does not already exist.
+   */
+  def createFile(path: Path): IO[Unit] = files.createFile(path)
+
+  /**
+   * Creates the specified file with the specified permissions. Fails if the
+   * parent path does not already exist.
+   */
+  def createFile(path: Path, permissions: Permissions): IO[Unit] =
+    files.createFile(path, permissions.some)
+
+  /** Creates a hard link with an existing file. */
+  def createLink(link: Path, existing: Path): IO[Unit] =
+    files.createLink(link, existing)
+
+  /** Creates a symbolic link which points to the supplied target. */
+  def createSymbolicLink(link: Path, target: Path): IO[Unit] =
+    files.createSymbolicLink(link, target)
+
+  /**
+   * Creates a symbolic link which points to the supplied target with optional
+   * permissions.
+   */
+  def createSymbolicLink(
+      link: Path,
+      target: Path,
+      permissions: Permissions
+  ): IO[Unit] =
+    files.createSymbolicLink(link, target, permissions.some)
+
+  /**
+   * Creates a temporary file. The created file is not automatically deleted -
+   * it is up to the operating system to decide when the file is deleted.
+   * Alternatively, use `tempFile` to get a resource, which is deleted upon
+   * resource finalization.
+   */
+  def createTempFile: IO[Path] = files.createTempFile
+
+  /**
+   * Creates a temporary file. The created file is not automatically deleted -
+   * it is up to the operating system to decide when the file is deleted.
+   * Alternatively, use `tempFile` to get a resource which deletes upon resource
+   * finalization.
+   *
+   * @param dir
+   *   the directory which the temporary file will be created in. Pass none to
+   *   use the default system temp directory
+   * @param prefix
+   *   the prefix string to be used in generating the file's name
+   * @param suffix
+   *   the suffix string to be used in generating the file's name
+   * @param permissions
+   *   permissions to set on the created file
+   */
+  def createTempFile(
+      dir: Option[Path],
+      prefix: String,
+      suffix: String,
+      permissions: Permissions
+  ): IO[Path] = files.createTempFile(dir, prefix, suffix, permissions.some)
+
+  /**
+   * Creates a temporary directory. The created directory is not automatically
+   * deleted - it is up to the operating system to decide when the file is
+   * deleted. Alternatively, use `tempDirectory` to get a resource which deletes
+   * upon resource finalization.
+   */
+  def createTempDirectory: IO[Path] = files.createTempDirectory
+
+  /**
+   * Creates a temporary directory. The created directory is not automatically
+   * deleted - it is up to the operating system to decide when the file is
+   * deleted. Alternatively, use `tempDirectory` to get a resource which deletes
+   * upon resource finalization.
+   *
+   * @param dir
+   *   the directory which the temporary directory will be created in. Pass none
+   *   to use the default system temp directory
+   * @param prefix
+   *   the prefix string to be used in generating the directory's name
+   * @param permissions
+   *   permissions to set on the created directory
+   */
+  def createTempDirectory(
+      dir: Option[Path],
+      prefix: String,
+      permissions: Permissions
+  ): IO[Path] = files.createTempDirectory(dir, prefix, permissions.some)
+
+  /** User's current working directory */
+  def currentWorkingDirectory: IO[Path] = files.currentWorkingDirectory
+
+  /**
+   * Deletes the specified file or empty directory, failing if it does not
+   * exist.
+   */
+  def delete(path: Path): IO[Unit] = files.delete(path)
+
+  /**
+   * Deletes the specified file or empty directory, passing if it does not
+   * exist.
+   */
+  def deleteIfExists(path: Path): IO[Boolean] = files.deleteIfExists(path)
+
+  /**
+   * Deletes the specified file or directory. If the path is a directory and is
+   * non-empty, its contents are recursively deleted. Symbolic links are not
+   * followed (but are deleted).
+   */
+  def deleteRecursively(
+      path: Path
+  ): IO[Unit] = deleteRecursively(path, false)
+
+  /**
+   * Deletes the specified file or directory. If the path is a directory and is
+   * non-empty, its contents are recursively deleted. Symbolic links are
+   * followed when `followLinks` is true.
+   */
+  def deleteRecursively(
+      path: Path,
+      followLinks: Boolean
+  ): IO[Unit] = files.deleteRecursively(path, followLinks)
+
+  /**
+   * Returns true if the specified path exists. Symbolic links are followed --
+   * see the overload for more details on links.
+   */
+  def exists(path: Path): IO[Boolean] = exists(path, true)
+
+  /**
+   * Returns true if the specified path exists. Symbolic links are followed when
+   * `followLinks` is true. For example, if the symbolic link `foo` points to
+   * `bar` and `bar` does not exist, `exists(Path("foo"), true)` returns `false`
+   * but `exists(Path("foo"), false)` returns `true`.
+   */
+  def exists(path: Path, followLinks: Boolean): IO[Boolean] =
+    files.exists(path, followLinks)
+
+  /**
+   * Gets `BasicFileAttributes` for the supplied path. Symbolic links are not
+   * followed.
+   */
+  def getBasicFileAttributes(path: Path): IO[BasicFileAttributes] =
+    getBasicFileAttributes(path, false)
+
+  /**
+   * Gets `BasicFileAttributes` for the supplied path. Symbolic links are
+   * followed when `followLinks` is true.
+   */
+  def getBasicFileAttributes(
+      path: Path,
+      followLinks: Boolean
+  ): IO[BasicFileAttributes] = files.getBasicFileAttributes(path, followLinks)
+
+  /**
+   * Gets the last modified time of the supplied path. The last modified time is
+   * represented as a duration since the Unix epoch. Symbolic links are
+   * followed.
+   */
+  def getLastModifiedTime(path: Path): IO[FiniteDuration] =
+    getLastModifiedTime(path, true)
+
+  /**
+   * Gets the last modified time of the supplied path. The last modified time is
+   * represented as a duration since the Unix epoch. Symbolic links are followed
+   * when `followLinks` is true.
+   */
+  def getLastModifiedTime(
+      path: Path,
+      followLinks: Boolean
+  ): IO[FiniteDuration] = files.getLastModifiedTime(path, followLinks)
+
+  /**
+   * Gets the POSIX attributes for the supplied path. Symbolic links are not
+   * followed.
+   */
+  def getPosixFileAttributes(path: Path): IO[PosixFileAttributes] =
+    getPosixFileAttributes(path, false)
+
+  /**
+   * Gets the POSIX attributes for the supplied path. Symbolic links are
+   * followed when `followLinks` is true.
+   */
+  def getPosixFileAttributes(
+      path: Path,
+      followLinks: Boolean
+  ): IO[PosixFileAttributes] = files.getPosixFileAttributes(path, followLinks)
+
+  /**
+   * Gets the POSIX permissions of the supplied path. Symbolic links are
+   * followed.
+   */
+  def getPosixPermissions(path: Path): IO[PosixPermissions] =
+    getPosixPermissions(path, true)
+
+  /**
+   * Gets the POSIX permissions of the supplied path. Symbolic links are
+   * followed when `followLinks` is true.
+   */
+  def getPosixPermissions(
+      path: Path,
+      followLinks: Boolean
+  ): IO[PosixPermissions] = files.getPosixPermissions(path, followLinks)
+
+  /**
+   * Returns true if the supplied path exists and is a directory. Symbolic links
+   * are followed.
+   */
+  def isDirectory(path: Path): IO[Boolean] = isDirectory(path, true)
+
+  /**
+   * Returns true if the supplied path exists and is a directory. Symbolic links
+   * are followed when `followLinks` is true.
+   */
+  def isDirectory(path: Path, followLinks: Boolean): IO[Boolean] =
+    files.isDirectory(path, followLinks)
+
+  /** Returns true if the supplied path exists and is executable. */
+  def isExecutable(path: Path): IO[Boolean] = files.isExecutable(path)
+
+  /**
+   * Returns true if the supplied path is a hidden file (note: may not check for
+   * existence).
+   */
+  def isHidden(path: Path): IO[Boolean] = files.isHidden(path)
+
+  /** Returns true if the supplied path exists and is readable. */
+  def isReadable(path: Path): IO[Boolean] = files.isReadable(path)
+
+  /**
+   * Returns true if the supplied path is a regular file. Symbolic links are
+   * followed.
+   */
+  def isRegularFile(path: Path): IO[Boolean] = isRegularFile(path, true)
+
+  /**
+   * Returns true if the supplied path is a regular file. Symbolic links are
+   * followed when `followLinks` is true.
+   */
+  def isRegularFile(path: Path, followLinks: Boolean): IO[Boolean] =
+    files.isRegularFile(path, followLinks)
+
+  /** Returns true if the supplied path is a symbolic link. */
+  def isSymbolicLink(path: Path): IO[Boolean] = files.isSymbolicLink(path)
+
+  /** Returns true if the supplied path exists and is writable. */
+  def isWritable(path: Path): IO[Boolean] = files.isWritable(path)
+
+  /** Returns true if the supplied paths reference the same file. */
+  def isSameFile(path1: Path, path2: Path): IO[Boolean] =
+    files.isSameFile(path1, path2)
+
+  /** Returns the line separator for the specific OS */
+  def lineSeparator: String = files.lineSeparator
+
+  /** Gets the contents of the specified directory. */
+  def list(path: Path): Stream[IO, Path] = files.list(path)
+
+  /**
+   * Moves the source to the target, failing if source does not exist or the
+   * target already exists. To replace the existing instead, use `move(source,
+   * target, CopyFlags(CopyFlag.ReplaceExisting))`.
+   */
+  def move(source: Path, target: Path): IO[Unit] =
+    move(source, target, CopyFlags.empty)
+
+  /**
+   * Moves the source to the target, following any directives supplied in the
+   * flags. By default, an error occurs if the target already exists, though
+   * this can be overriden via `CopyFlag.ReplaceExisting`.
+   */
+  def move(source: Path, target: Path, flags: CopyFlags): IO[Unit] =
+    files.move(source, target, flags)
+
+  /**
+   * Creates a `FileHandle` for the file at the supplied `Path`. The supplied
+   * flags indicate the mode used when opening the file (e.g. read, write,
+   * append) as well as the ability to specify additional options (e.g.
+   * automatic deletion at process exit).
+   */
+  def open(path: Path, flags: Flags): Resource[IO, FileHandle[IO]] =
+    files.open(path, flags)
+
+  /**
+   * Returns a `ReadCursor` for the specified path, using the supplied flags
+   * when opening the file.
+   */
+  def readCursor(path: Path, flags: Flags): Resource[IO, ReadCursor[IO]] =
+    files.readCursor(path, flags)
+
+  /**
+   * Returns the real path i.e. the actual location of `path`. The precise
+   * definition of this method is implementation dependent but in general it
+   * derives from this path, an absolute path that locates the same file as this
+   * path, but with name elements that represent the actual name of the
+   * directories and the file.
+   */
+  def realPath(path: Path): IO[Path] = files.realPath(path)
+
+  /**
+   * Sets the last modified, last access, and creation time fields of the
+   * specified path.
+   *
+   * Times which are supplied as `None` are not modified. E.g., `setTimes(p,
+   * Some(t), Some(t), None, false)` sets the last modified and last access time
+   * to `t` and does not change the creation time.
+   *
+   * If the path is a symbolic link and `followLinks` is true, the target of the
+   * link as times set. Otherwise, the link itself has times set.
+   */
+  def setFileTimes(
+      path: Path,
+      lastModified: Option[FiniteDuration],
+      lastAccess: Option[FiniteDuration],
+      creationTime: Option[FiniteDuration],
+      followLinks: Boolean
+  ): IO[Unit] = files.setFileTimes(
+    path,
+    lastModified,
+    lastAccess,
+    creationTime,
+    followLinks
+  )
+
+  /**
+   * Sets the POSIX permissions for the supplied path. Fails on non-POSIX file
+   * systems.
+   */
+  def setPosixPermissions(path: Path, permissions: PosixPermissions): IO[Unit] =
+    files.setPosixPermissions(path, permissions)
+
+  /** Gets the size of the supplied path, failing if it does not exist. */
+  def size(path: Path): IO[Long] = files.size(path)
+
+  /**
+   * Creates a temporary file and deletes it upon finalization of the returned
+   * resource.
+   */
+  def tempFile: Resource[IO, Path] = files.tempFile(None, "", ".tmp", None)
+
+  /**
+   * Creates a temporary file and deletes it upon finalization of the returned
+   * resource.
+   *
+   * @param dir
+   *   the directory which the temporary file will be created in. Pass in None
+   *   to use the default system temp directory
+   * @param prefix
+   *   the prefix string to be used in generating the file's name
+   * @param suffix
+   *   the suffix string to be used in generating the file's name
+   * @param permissions
+   *   permissions to set on the created file
+   * @return
+   *   a resource containing the path of the temporary file
+   */
+  def tempFile(
+      dir: Option[Path],
+      prefix: String,
+      suffix: String,
+      permissions: Permissions
+  ): Resource[IO, Path] = files.tempFile(dir, prefix, suffix, permissions.some)
+
+  /**
+   * Creates a temporary directory and deletes it upon finalization of the
+   * returned resource.
+   */
+  def tempDirectory: Resource[IO, Path] = files.tempDirectory(None, "", None)
+
+  /**
+   * Creates a temporary directory and deletes it upon finalization of the
+   * returned resource.
+   *
+   * @param dir
+   *   the directory which the temporary directory will be created in. Pass in
+   *   None to use the default system temp directory
+   * @param prefix
+   *   the prefix string to be used in generating the directory's name
+   * @param permissions
+   *   permissions to set on the created file
+   * @return
+   *   a resource containing the path of the temporary directory
+   */
+  def tempDirectory(
+      dir: Option[Path],
+      prefix: String,
+      permissions: Permissions
+  ): Resource[IO, Path] = files.tempDirectory(dir, prefix, permissions.some)
+
+  /** User's home directory */
+  def userHome: IO[Path] = files.userHome
+
 }

--- a/core/src/main/scala/io/chrisdavenport/shellfish/FilesOs.scala
+++ b/core/src/main/scala/io/chrisdavenport/shellfish/FilesOs.scala
@@ -295,7 +295,7 @@ object FilesOs {
    * Similar to append, but appends a single line to the end file as a newline
    * instead of overwriting it.
    *
-   * Equivalent to `append(path)(s"\n$contents")`
+   * Equivalent to `append(path, '\n' + contents)`
    *
    * @param path
    *   The path to write to

--- a/core/src/main/scala/io/chrisdavenport/shellfish/FilesOs.scala
+++ b/core/src/main/scala/io/chrisdavenport/shellfish/FilesOs.scala
@@ -41,7 +41,7 @@ object FilesOs {
   // Read operations:
 
   /**
-   * Reads the contents of the fileat the path using UTF-8 decoding. Returns it
+   * Reads the contents of the file at the path using UTF-8 decoding. Returns it
    * as a String loaded in memory.
    *
    * @param path
@@ -94,7 +94,7 @@ object FilesOs {
   /**
    * Reads the contents of the file and deserializes its contents as `A` using
    * the provided codec.
-   * @param A
+   * @tparam A
    *   The type to read the file as
    * @param path
    *   The path to read from
@@ -119,7 +119,7 @@ object FilesOs {
   // Write operations:
 
   /**
-   * This function overwites the contents of the file at the path using UTF-8
+   * This function overwrites the contents of the file at the path using UTF-8
    * encoding with the contents provided in form of a entire string loaded in
    * memory.
    *
@@ -137,7 +137,7 @@ object FilesOs {
       .drain
 
   /**
-   * This function overwites the contents of the file at the path using the
+   * This function overwrites the contents of the file at the path using the
    * provided charset with the contents provided in form of a entire string
    * loaded in memory.
    *
@@ -162,7 +162,7 @@ object FilesOs {
       .drain
 
   /**
-   * This function overwites the contents of the file at the path with the
+   * This function overwrites the contents of the file at the path with the
    * contents provided in form of bytes loaded in memory.
    *
    * @param path
@@ -179,7 +179,7 @@ object FilesOs {
       .drain
 
   /**
-   * This function overwites the contents of the file at the path using UTF-8
+   * This function overwrites the contents of the file at the path using UTF-8
    * encoding with the contents provided. Each content inside the list is
    * written as a line in the file.
    *
@@ -201,7 +201,7 @@ object FilesOs {
    * provided and returns the number of bytes written. The codec is used to
    * translate the type A into a ByteVector so it can be parsed into the file.
    *
-   * @param A
+   * @tparam A
    *   The type of the contents to write
    * @param path
    *   The path to write to
@@ -309,7 +309,7 @@ object FilesOs {
    * Similar to `write`, but appends to the file instead of overwriting it.
    * Saves the content at the end of the file in form of a type `A`.
    *
-   * @param A
+   * @tparam A
    *   The type of the contents to write
    * @param path
    *   The path to write to
@@ -334,7 +334,7 @@ object FilesOs {
   /**
    * Copies the source to the target, following any directives supplied in the
    * flags. By default, an error occurs if the target already exists, though
-   * this can be overriden via CopyFlag.ReplaceExisting.
+   * this can be overridden via CopyFlag.ReplaceExisting.
    */
   def copy(source: Path, target: Path, flags: CopyFlags): IO[Unit] =
     files.copy(source, target, flags)
@@ -353,7 +353,7 @@ object FilesOs {
     files.createDirectories(path, permissions.some)
 
   /**
-   * Creates the specified directory and any non-existant parent directories.
+   * Creates the specified directory and any non-existent parent directories.
    */
   def createDirectories(path: Path): IO[Unit] = files.createDirectories(path)
 
@@ -639,7 +639,7 @@ object FilesOs {
   /**
    * Moves the source to the target, following any directives supplied in the
    * flags. By default, an error occurs if the target already exists, though
-   * this can be overriden via `CopyFlag.ReplaceExisting`.
+   * this can be overridden via `CopyFlag.ReplaceExisting`.
    */
   def move(source: Path, target: Path, flags: CopyFlags): IO[Unit] =
     files.move(source, target, flags)

--- a/core/src/main/scala/io/chrisdavenport/shellfish/FilesOs.scala
+++ b/core/src/main/scala/io/chrisdavenport/shellfish/FilesOs.scala
@@ -21,30 +21,50 @@
 
 package io.chrisdavenport.shellfish
 
-import cats.syntax.all.*
 import cats.effect.IO
 
 import fs2.{Stream, Chunk}
-import fs2.interop.scodec.*
 import fs2.io.file.{Files, Path, Flags}
 
-import scodec.{Codec, codecs}
+import scodec.Codec
 import scodec.bits.ByteVector
+
+import java.nio.charset.Charset
 
 object FilesOs {
 
-  val files = Files[IO]
+  val files: Files[IO] = Files[IO]
 
   // Read operations:
 
   /**
-   * Reads the contents of the file at the path and returns it as a String.
+   * Reads the contents of the fileat the path using UTF-8 decoding. Returns it
+   * as a String loaded in memory.
+   *
    * @param path
    *   The path to read from
    * @return
    *   The file loaded in memory as a String
    */
   def read(path: Path): IO[String] = files.readUtf8(path).compile.string
+
+  /**
+   * Reads the contents of the file at the path using the provided charset.
+   * Returns it as a String loaded in memory.
+   *
+   * @param charset
+   *   The charset to use to decode the file
+   * @param path
+   *   The path to read from
+   * @return
+   *   The file loaded in memory as a String
+   */
+  def readWithCharset(charset: Charset)(path: Path): IO[String] =
+    files
+      .readAll(path)
+      .through(fs2.text.decodeWithCharset(charset))
+      .compile
+      .string
 
   /**
    * Reads the contents of the file at the path and returns it as a ByteVector.
@@ -57,38 +77,31 @@ object FilesOs {
     files.readAll(path).compile.to(ByteVector)
 
   /**
-   * Reads the contents of the file at the path and returns it line by line as a
-   * Vector of Strings.
+   * Reads the contents of the file at the path using UTF-8 decoding and returns
+   * it line by line as a List of Strings.
    *
    * @param path
    *   The path to read from
    * @return
    *   The file loaded in memory as a collection of lines of Strings
    */
-  def readLines(path: Path): IO[Vector[String]] =
-    files.readUtf8Lines(path).compile.toVector
+  def readLines(path: Path): IO[List[String]] =
+    files.readUtf8Lines(path).compile.toList
 
   /**
-   * Reads the contents of the file and loads it as a type `A` using the
-   * provided codec.
+   * Reads the contents of the file and deserializes its contents as `A` using
+   * the provided codec.
    * @param A
    *   The type to read the file as
    * @param path
    *   The path to read from
-   * @param codec
+   * @param Codec[A]
    *   The codec that translates the file contents into the type `A`
    * @return
    *   The file loaded in memory as a type `A`
-   * @throws java.lang.Exception
-   *   if the file cannot be read or the contents cannot be parsed into the type
-   *   `A`
    */
-  def readAs[A](path: Path)(implicit codec: Codec[A]): IO[A] =
-    readBytes(path)
-      .map(bytes => codec.decodeValue(bytes.bits).require)
-      .handleErrorWith { e =>
-        new Exception(s"Failed to read file at $path", e).raiseError[IO, A]
-      }
+  def readAs[A: Codec](path: Path): IO[A] =
+    readBytes(path).map(bytes => Codec[A].decodeValue(bytes.bits).require)
 
   /**
    * The function reads the contents of the file at the path and returns it as a
@@ -98,38 +111,27 @@ object FilesOs {
    * @return
    *   A Stream of Bytes
    */
-  def stream(path: Path): Stream[IO, Byte] = files.readAll(path)
-
-  /**
-   * The function reads the contents of the file at the `path` and returns it as
-   * a `Chunk[Bytes]`,
-   * @param path
-   *   The path to read from
-   * @return
-   *   The file loaded in memory as a Chunk of Bytes
-   */
-  def chunk(path: Path): IO[Chunk[Byte]] = files.readAll(path).compile.to(Chunk)
+  def readStream(path: Path): Stream[IO, Byte] = files.readAll(path)
 
   // Write operations:
 
   /**
-   * This function overwites the contents of the file at the path with the
-   * contents provided in form of a entire string loaded in memory.
+   * This function overwites the contents of the file at the path using UTF-8
+   * encoding with the contents provided in form of a entire string loaded in
+   * memory.
    *
    * @param path
    *   The path to write to
    * @param contents
    *   The contents to write to the file
-   * @return
-   *   The number of bytes written
    */
-  def write(path: Path)(contents: String): IO[Long] =
+  def write(path: Path)(contents: String): IO[Unit] =
     Stream
       .emit(contents)
       .covary[IO]
       .through(files.writeUtf8(path))
       .compile
-      .count
+      .drain
 
   /**
    * This function overwites the contents of the file at the path with the
@@ -139,37 +141,32 @@ object FilesOs {
    *   The path to write to
    * @param contents
    *   The contents to write to the file
-   * @return
-   *   The number of bytes written
    */
-  def writeBytes(path: Path)(contents: ByteVector): IO[Long] =
+  def writeBytes(path: Path)(contents: ByteVector): IO[Unit] =
     Stream
-      .emit(contents)
+      .chunk(Chunk.byteVector(contents))
       .covary[IO]
-      .through(StreamEncoder.many(codecs.bytes).toPipeByte)
       .through(files.writeAll(path))
       .compile
-      .count
+      .drain
 
   /**
-   * This function overwites the contents of the file at the path with the
-   * contents provided. Each content inside the vector is written as a line in
-   * the file.
+   * This function overwites the contents of the file at the path using UTF-8
+   * encoding with the contents provided. Each content inside the list is
+   * written as a line in the file.
    *
    * @param path
    *   The path to write to
    * @param contents
    *   The contents to write to the file
-   * @return
-   *   The number of bytes written
    */
-  def writeLines(path: Path)(contents: Vector[String]): IO[Long] =
+  def writeLines(path: Path)(contents: Seq[String]): IO[Unit] =
     Stream
       .emits(contents)
       .covary[IO]
       .through(files.writeUtf8Lines(path))
       .compile
-      .count
+      .drain
 
   /**
    * The functions writes the contents of the file at the path with the contents
@@ -182,19 +179,11 @@ object FilesOs {
    *   The path to write to
    * @param contents
    *   The contents to write to the file
-   * @param codec
+   * @param Codec[A]
    *   The codec that translates the type A into a ByteVector
-   * @return
-   *   The number of bytes written
    */
-  def writeAs[A](path: Path)(contents: A)(implicit codec: Codec[A]): IO[Long] =
-    Stream
-      .emit(contents)
-      .covary[IO]
-      .through(StreamEncoder.many(codec).toPipeByte)
-      .through(files.writeAll(path))
-      .compile
-      .count
+  def writeAs[A: Codec](path: Path)(contents: A): IO[Unit] =
+    writeBytes(path)(Codec[A].encode(contents).require.bytes)
 
   /**
    * Similar to `write`, but appends to the file instead of overwriting it.
@@ -204,16 +193,14 @@ object FilesOs {
    *   The path to write to
    * @param contents
    *   The contents to write to the file
-   * @return
-   *   The number of bytes written
    */
-  def append(path: Path)(contents: String): IO[Long] =
+  def append(path: Path)(contents: String): IO[Unit] =
     Stream
       .emit(contents)
       .covary[IO]
       .through(files.writeUtf8(path, Flags.Append))
       .compile
-      .count
+      .drain
 
   /**
    * Similar to `write`, but appends to the file instead of overwriting it.
@@ -223,37 +210,46 @@ object FilesOs {
    *   The path to write to
    * @param contents
    *   The contents to write to the file
-   * @return
-   *   The number of bytes written
    */
-  def appendBytes(path: Path)(contents: ByteVector): IO[Long] =
+  def appendBytes(path: Path)(contents: ByteVector): IO[Unit] =
     Stream
-      .emit(contents)
+      .chunk(Chunk.byteVector(contents))
       .covary[IO]
-      .through(StreamEncoder.many(codecs.bytes).toPipeByte)
       .through(files.writeAll(path, Flags.Append))
       .compile
-      .count
+      .drain
 
   /**
    * Similar to `write`, but appends to the file instead of overwriting it.
-   * Saves each line of the content at the end of the file in form of a Vector
-   * of Strings.
+   * Saves each line of the content at the end of the file in form of a List of
+   * Strings.
    *
    * @param path
    *   The path to write to
    * @param contents
    *   The contents to write to the file
-   * @return
-   *   The number of bytes written
    */
-  def appendLines(path: Path)(contents: Vector[String]): IO[Long] =
+  def appendLines(path: Path)(contents: Seq[String]): IO[Unit] =
     Stream
       .emits(contents)
       .covary[IO]
       .through(files.writeUtf8Lines(path, Flags.Append))
       .compile
-      .count
+      .drain
+
+  /**
+   * Similar to append, but appends a single line to the end file as a newline
+   * instead of overwriting it.
+   *
+   * Equivalent to `append(path)(s"\n$contents")`
+   *
+   * @param path
+   *   The path to write to
+   * @param contents
+   *   The contents to write to the file
+   */
+  def appendLine(path: Path)(contents: String): IO[Unit] =
+    appendLines(path)(List(contents))
 
   /**
    * Similar to `write`, but appends to the file instead of overwriting it.
@@ -265,17 +261,9 @@ object FilesOs {
    *   The path to write to
    * @param contents
    *   The contents to write to the file
-   * @param codec
+   * @param Codec[A]
    *   The codec that translates the type A into a ByteVector
-   * @return
-   *   The number of bytes written
    */
-  def appendAs[A](path: Path)(contents: A)(implicit codec: Codec[A]): IO[Long] =
-    Stream
-      .emit(contents)
-      .covary[IO]
-      .through(StreamEncoder.many(codec).toPipeByte)
-      .through(files.writeAll(path, Flags.Append))
-      .compile
-      .count
+  def appendAs[A: Codec](path: Path)(contents: A): IO[Unit] =
+    appendBytes(path)(Codec[A].encode(contents).require.bytes)
 }

--- a/core/src/main/scala/io/chrisdavenport/shellfish/FilesOs.scala
+++ b/core/src/main/scala/io/chrisdavenport/shellfish/FilesOs.scala
@@ -1,0 +1,260 @@
+package io.chrisdavenport.shellfish
+
+import cats.syntax.all.*
+import cats.effect.IO
+
+import fs2.{Stream, Chunk}
+import fs2.interop.scodec.*
+import fs2.io.file.{Files, Path, Flags}
+
+import scodec.{Codec, codecs}
+import scodec.bits.ByteVector
+
+object FilesOs {
+
+  val files = Files[IO]
+
+  // Read operations:
+
+  /**
+   * Reads the contents of the file at the path and returns it as a String.
+   * @param path
+   *   The path to read from
+   * @return
+   *   The file loaded in memory as a String
+   */
+  def read(path: Path): IO[String] = files.readUtf8(path).compile.string
+
+  /**
+   * Reads the contents of the file at the path and returns it as a ByteVector.
+   * @param path
+   *   The path to read from
+   * @return
+   *   The file loaded in memory as a ByteVector
+   */
+  def readBytes(path: Path): IO[ByteVector] =
+    files.readAll(path).compile.to(ByteVector)
+
+  /**
+   * Reads the contents of the file at the path and returns it line by line as a
+   * Vector of Strings.
+   *
+   * @param path
+   *   The path to read from
+   * @return
+   *   The file loaded in memory as a collection of lines of Strings
+   */
+  def readLines(path: Path): IO[Vector[String]] =
+    files.readUtf8Lines(path).compile.toVector
+
+  /**
+   * Reads the contents of the file and loads it as a type `A` using the
+   * provided codec.
+   * @param A
+   *   The type to read the file as
+   * @param path
+   *   The path to read from
+   * @param codec
+   *   The codec that translates the file contents into the type `A`
+   * @return
+   *   The file loaded in memory as a type `A`
+   * @throws Exception
+   *   if the file cannot be read or the contents cannot be parsed into the type
+   *   `A`
+   */
+  def readAs[A](path: Path)(implicit codec: Codec[A]): IO[A] =
+    readBytes(path)
+      .map(bytes => codec.decodeValue(bytes.bits).require)
+      .handleErrorWith { e =>
+        new Exception(s"Failed to read file at $path", e).raiseError[IO, A]
+      }
+
+  /**
+   * The function reads the contents of the file at the path and returns it as a
+   * Stream of Bytes, useful when working with large files.
+   * @param path
+   *   The path to read from
+   * @return
+   *   A Stream of Bytes
+   */
+  def stream(path: Path): Stream[IO, Byte] = files.readAll(path)
+
+  /**
+   * The function reads the contents of the file at the `path` and returns it as
+   * a `Chunk[Bytes]`,
+   * @param path
+   *   The path to read from
+   * @return
+   *   The file loaded in memory as a Chunk of Bytes
+   */
+  def chunk(path: Path): IO[Chunk[Byte]] = files.readAll(path).compile.to(Chunk)
+
+  // Write operations:
+
+  /**
+   * This function overwites the contents of the file at the path with the
+   * contents provided in form of a entire string loaded in memory.
+   *
+   * @param path
+   *   The path to write to
+   * @param contents
+   *   The contents to write to the file
+   * @return
+   *   The number of bytes written
+   */
+  def write(path: Path)(contents: String): IO[Long] =
+    Stream
+      .emit(contents)
+      .covary[IO]
+      .through(files.writeUtf8(path))
+      .compile
+      .count
+
+  /**
+   * This function overwites the contents of the file at the path with the
+   * contents provided in form of bytes loaded in memory.
+   *
+   * @param path
+   *   The path to write to
+   * @param contents
+   *   The contents to write to the file
+   * @return
+   *   The number of bytes written
+   */
+  def writeBytes(path: Path)(contents: ByteVector): IO[Long] =
+    Stream
+      .emit(contents)
+      .covary[IO]
+      .through(StreamEncoder.many(codecs.bytes).toPipeByte)
+      .through(files.writeAll(path))
+      .compile
+      .count
+
+  /**
+   * This function overwites the contents of the file at the path with the
+   * contents provided. Each content inside the vector is written as a line in
+   * the file.
+   *
+   * @param path
+   *   The path to write to
+   * @param contents
+   *   The contents to write to the file
+   * @return
+   *   The number of bytes written
+   */
+  def writeLines(path: Path)(contents: Vector[String]): IO[Long] =
+    Stream
+      .emits(contents)
+      .covary[IO]
+      .through(files.writeUtf8Lines(path))
+      .compile
+      .count
+
+  /**
+   * The functions writes the contents of the file at the path with the contents
+   * provided and returns the number of bytes written. The codec is used to
+   * translate the type A into a ByteVector so it can be parsed into the file.
+   *
+   * @param A
+   *   The type of the contents to write
+   * @param path
+   *   The path to write to
+   * @param contents
+   *   The contents to write to the file
+   * @param codec
+   *   The codec that translates the type A into a ByteVector
+   * @return
+   *   The number of bytes written
+   */
+  def writeAs[A](path: Path)(contents: A)(implicit codec: Codec[A]): IO[Long] =
+    Stream
+      .emit(contents)
+      .covary[IO]
+      .through(StreamEncoder.many(codec).toPipeByte)
+      .through(files.writeAll(path))
+      .compile
+      .count
+
+  /**
+   * Similar to `write`, but appends to the file instead of overwriting it.
+   * Saves the content at the end of the file in form of a String.
+   *
+   * @param path
+   *   The path to write to
+   * @param contents
+   *   The contents to write to the file
+   * @return
+   *   The number of bytes written
+   */
+  def append(path: Path)(contents: String): IO[Long] =
+    Stream
+      .emit(contents)
+      .covary[IO]
+      .through(files.writeUtf8(path, Flags.Append))
+      .compile
+      .count
+
+  /**
+   * Similar to `write`, but appends to the file instead of overwriting it.
+   * Saves the content at the end of the file in form of a ByteVector.
+   *
+   * @param path
+   *   The path to write to
+   * @param contents
+   *   The contents to write to the file
+   * @return
+   *   The number of bytes written
+   */
+  def appendBytes(path: Path)(contents: ByteVector): IO[Long] =
+    Stream
+      .emit(contents)
+      .covary[IO]
+      .through(StreamEncoder.many(codecs.bytes).toPipeByte)
+      .through(files.writeAll(path, Flags.Append))
+      .compile
+      .count
+
+  /**
+   * Similar to `write`, but appends to the file instead of overwriting it.
+   * Saves each line of the content at the end of the file in form of a Vector
+   * of Strings.
+   *
+   * @param path
+   *   The path to write to
+   * @param contents
+   *   The contents to write to the file
+   * @return
+   *   The number of bytes written
+   */
+  def appendLines(path: Path)(contents: Vector[String]): IO[Long] =
+    Stream
+      .emits(contents)
+      .covary[IO]
+      .through(files.writeUtf8Lines(path, Flags.Append))
+      .compile
+      .count
+
+  /**
+   * Similar to `write`, but appends to the file instead of overwriting it.
+   * Saves the content at the end of the file in form of a type `A`.
+   *
+   * @param A
+   *   The type of the contents to write
+   * @param path
+   *   The path to write to
+   * @param contents
+   *   The contents to write to the file
+   * @param codec
+   *   The codec that translates the type A into a ByteVector
+   * @return
+   *   The number of bytes written
+   */
+  def appendAs[A](path: Path)(contents: A)(implicit codec: Codec[A]): IO[Long] =
+    Stream
+      .emit(contents)
+      .covary[IO]
+      .through(StreamEncoder.many(codec).toPipeByte)
+      .through(files.writeAll(path, Flags.Append))
+      .compile
+      .count
+}

--- a/core/src/main/scala/io/chrisdavenport/shellfish/FilesOs.scala
+++ b/core/src/main/scala/io/chrisdavenport/shellfish/FilesOs.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2024 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package io.chrisdavenport.shellfish
 
 import cats.syntax.all.*

--- a/core/src/main/scala/io/chrisdavenport/shellfish/syntax/path/package.scala
+++ b/core/src/main/scala/io/chrisdavenport/shellfish/syntax/path/package.scala
@@ -41,7 +41,7 @@ package object path {
   implicit class FileOps(val path: Path) extends AnyVal {
 
     /**
-     * Reads the contents of the fileat the path using UTF-8 decoding. Returns
+     * Reads the contents of the file at the path using UTF-8 decoding. Returns
      * it as a String loaded in memory.
      *
      * @param path
@@ -89,7 +89,7 @@ package object path {
     /**
      * Reads the contents of the file and deserializes its contents as `A` using
      * the provided codec.
-     * @param A
+     * @tparam A
      *   The type to read the file as
      * @param path
      *   The path to read from
@@ -113,7 +113,7 @@ package object path {
     // Write operations:
 
     /**
-     * This function overwites the contents of the file at the path using UTF-8
+     * This function overwrites the contents of the file at the path using UTF-8
      * encoding with the contents provided in form of a entire string loaded in
      * memory.
      *
@@ -125,7 +125,7 @@ package object path {
     def write(contents: String): IO[Unit] = FilesOs.write(path, contents)
 
     /**
-     * This function overwites the contents of the file at the path using the
+     * This function overwrites the contents of the file at the path using the
      * provided charset with the contents provided in form of a entire string
      * loaded in memory.
      *
@@ -140,7 +140,7 @@ package object path {
       FilesOs.writeWithCharset(path, contents, charset)
 
     /**
-     * This function overwites the contents of the file at the path with the
+     * This function overwrites the contents of the file at the path with the
      * contents provided in form of bytes loaded in memory.
      *
      * @param path
@@ -152,7 +152,7 @@ package object path {
       FilesOs.writeBytes(path, contents)
 
     /**
-     * This function overwites the contents of the file at the path using UTF-8
+     * This function overwrites the contents of the file at the path using UTF-8
      * encoding with the contents provided. Each content inside the list is
      * written as a line in the file.
      *
@@ -170,7 +170,7 @@ package object path {
      * used to translate the type A into a ByteVector so it can be parsed into
      * the file.
      *
-     * @param A
+     * @tparam A
      *   The type of the contents to write
      * @param path
      *   The path to write to
@@ -255,7 +255,7 @@ package object path {
      * Similar to `write`, but appends to the file instead of overwriting it
      * using the given `Codec[A]`
      *
-     * @param A
+     * @tparam A
      *   The type of the contents to write
      * @param path
      *   The path to write to
@@ -280,7 +280,7 @@ package object path {
     /**
      * Copies the source to the target, following any directives supplied in the
      * flags. By default, an error occurs if the target already exists, though
-     * this can be overriden via CopyFlag.ReplaceExisting.
+     * this can be overridden via CopyFlag.ReplaceExisting.
      */
     def copy(target: Path, flags: CopyFlags): IO[Unit] =
       FilesOs.copy(path, target, flags)
@@ -357,9 +357,7 @@ package object path {
      * is non-empty, its contents are recursively deleted. Symbolic links are
      * not followed (but are deleted).
      */
-    def deleteRecursively(
-        path: Path
-    ): IO[Unit] = FilesOs.deleteRecursively(path)
+    def deleteRecursively: IO[Unit] = FilesOs.deleteRecursively(path)
 
     /**
      * Deletes the specified file or directory. If the path is a directory and

--- a/core/src/main/scala/io/chrisdavenport/shellfish/syntax/path/package.scala
+++ b/core/src/main/scala/io/chrisdavenport/shellfish/syntax/path/package.scala
@@ -75,7 +75,7 @@ package object path {
      *   The codec that translates the file contents into the type `A`
      * @return
      *   The file loaded in memory as a type `A`
-     * @throws Exception
+     * @throws java.lang.Exception
      *   if the file cannot be read or the contents cannot be parsed into the
      *   type `A`
      */

--- a/core/src/main/scala/io/chrisdavenport/shellfish/syntax/path/package.scala
+++ b/core/src/main/scala/io/chrisdavenport/shellfish/syntax/path/package.scala
@@ -241,7 +241,7 @@ package object path {
      * Similar to append, but appends a single line to the end file as a newline
      * instead of overwriting it.
      *
-     * Equivalent to `path.append(s"\n$contents")`
+     * Equivalent to `path.append('\n' + contents)`
      *
      * @param path
      *   The path to write to

--- a/core/src/main/scala/io/chrisdavenport/shellfish/syntax/path/package.scala
+++ b/core/src/main/scala/io/chrisdavenport/shellfish/syntax/path/package.scala
@@ -1,0 +1,346 @@
+package io.chrisdavenport.shellfish
+package syntax
+
+import cats.effect.IO
+
+import fs2.io.file.*
+
+import scodec.bits.ByteVector
+import scodec.Codec
+
+import scala.concurrent.duration.FiniteDuration
+
+package object path {
+
+  implicit class ReadWriteOps(val path: Path) extends AnyVal {
+
+    /**
+     * Reads the contents of the file at the path and returns it as a String.
+     * @param path
+     *   The path to read from
+     * @return
+     *   The file loaded in memory as a String
+     */
+    def read: IO[String] = FilesOs.read(path)
+
+    /**
+     * Reads the contents of the file at the path and returns it as a
+     * ByteVector.
+     * @param path
+     *   The path to read from
+     * @return
+     *   The file loaded in memory as a ByteVector
+     */
+    def readBytes: IO[ByteVector] = FilesOs.readBytes(path)
+
+    /**
+     * Reads the contents of the file at the path and returns it line by line as
+     * a Vector of Strings.
+     * @param path
+     *   The path to read from
+     * @return
+     *   The file loaded in memory as a collection of lines of Strings
+     */
+    def readLines: IO[Vector[String]] = FilesOs.readLines(path)
+
+    /**
+     * Reads the contents of the file and loads it as a type `A` using the
+     * provided codec.
+     * @param A
+     *   The type to read the file as
+     * @param path
+     *   The path to read from
+     * @param codec
+     *   The codec that translates the file contents into the type `A`
+     * @return
+     *   The file loaded in memory as a type `A`
+     * @throws Exception
+     *   if the file cannot be read or the contents cannot be parsed into the
+     *   type `A`
+     */
+    def readAs[A](implicit codec: scodec.Codec[A]): IO[A] = FilesOs.readAs(path)
+
+    /**
+     * The function reads the contents of the file at the path and returns it as
+     * a Stream of Bytes, useful when working with large files.
+     * @param path
+     *   The path to read from
+     * @return
+     *   A Stream of Bytes
+     */
+    def stream: fs2.Stream[IO, Byte] = FilesOs.stream(path)
+
+    /**
+     * The function reads the contents of the file at the `path` and returns it
+     * as a `Chunk[Bytes]`,
+     * @param path
+     *   The path to read from
+     * @return
+     *   The file loaded in memory as a Chunk of Bytes
+     */
+    def chunk: IO[fs2.Chunk[Byte]] = FilesOs.chunk(path)
+
+    // Write operations:
+
+    /**
+     * This function overwites the contents of the file at the path with the
+     * contents provided in form of a entire string loaded in memory.
+     *
+     * @param path
+     *   The path to write to
+     * @param contents
+     *   The contents to write to the file
+     * @return
+     *   The number of bytes written
+     */
+    def write(contents: String): IO[Long] = FilesOs.write(path)(contents)
+
+    /**
+     * This function overwites the contents of the file at the path with the
+     * contents provided in form of bytes loaded in memory.
+     *
+     * @param path
+     *   The path to write to
+     * @param contents
+     *   The contents to write to the file
+     * @return
+     *   The number of bytes written
+     */
+    def writeBytes(contents: ByteVector): IO[Long] =
+      FilesOs.writeBytes(path)(contents)
+
+    /**
+     * This function overwites the contents of the file at the path with the
+     * contents provided. Each content inside the vector is written as a line in
+     * the file.
+     *
+     * @param path
+     *   The path to write to
+     * @param contents
+     *   The contents to write to the file
+     * @return
+     *   The number of bytes written
+     */
+    def writeLines(contents: Vector[String]): IO[Long] =
+      FilesOs.writeLines(path)(contents)
+
+    /**
+     * The functions writes the contents of the file at the path with the
+     * contents provided and returns the number of bytes written. The codec is
+     * used to translate the type A into a ByteVector so it can be parsed into
+     * the file.
+     *
+     * @param A
+     *   The type of the contents to write
+     * @param path
+     *   The path to write to
+     * @param contents
+     *   The contents to write to the file
+     * @param codec
+     *   The codec that translates the type A into a ByteVector
+     * @return
+     *   The number of bytes written
+     */
+    def writeAs[A](contents: A)(implicit codec: Codec[A]): IO[Long] =
+      FilesOs.writeAs(path)(contents)
+
+    /**
+     * Similar to `write`, but appends to the file instead of overwriting it.
+     * Saves the content at the end of the file in form of a String.
+     *
+     * @param path
+     *   The path to write to
+     * @param contents
+     *   The contents to write to the file
+     * @return
+     *   The number of bytes written
+     */
+    def append(contents: String): IO[Long] = FilesOs.append(path)(contents)
+
+    /**
+     * Similar to `write`, but appends to the file instead of overwriting it.
+     * Saves the content at the end of the file in form of a ByteVector.
+     *
+     * @param path
+     *   The path to write to
+     * @param contents
+     *   The contents to write to the file
+     * @return
+     *   The number of bytes written
+     */
+    def appendBytes(contents: ByteVector): IO[Long] =
+      FilesOs.appendBytes(path)(contents)
+
+    /**
+     * Similar to `write`, but appends to the file instead of overwriting it.
+     * Saves each line of the content at the end of the file in form of a Vector
+     * of Strings.
+     *
+     * @param path
+     *   The path to write to
+     * @param contents
+     *   The contents to write to the file
+     * @return
+     *   The number of bytes written
+     */
+    def appendLines(contents: Vector[String]): IO[Long] =
+      FilesOs.appendLines(path)(contents)
+
+    /**
+     * Similar to `write`, but appends to the file instead of overwriting it.
+     *
+     * @param A
+     *   The type of the contents to write
+     * @param path
+     *   The path to write to
+     * @param contents
+     *   The contents to write to the file
+     * @param codec
+     *   The codec that translates the type A into a ByteVector
+     * @return
+     *   The number of bytes written
+     */
+    def appendAs[A](contents: A)(implicit codec: Codec[A]): IO[Long] =
+      FilesOs.appendAs[A](path)(contents)
+
+  }
+
+  private val files = Files[IO]
+
+  implicit class FileOps(val path: Path) extends AnyVal {
+
+    /**
+     * Copies the source to the target, failing if source does not exist or the
+     * target already exists. To replace the existing instead, use `copy(source,
+     * target, CopyFlags(CopyFlag.ReplaceExisting))`.
+     */
+    def copy(to: Path): IO[Unit] = files.copy(path, to)
+
+    /**
+     * Creates the specified directory. Fails if the parent path does not
+     * already exist.
+     */
+    def createDirectory: IO[Unit] = files.createDirectories(path)
+
+    /**
+     * Creates the specified directory with the specified permissions. Fails if
+     * the parent path does not already exist.
+     */
+    def createDirectory(permissions: Option[Permissions]): IO[Unit] =
+      files.createDirectories(path, permissions)
+
+    /**
+     * Creates the specified directory and any non-existant parent directories.
+     */
+    def createFile: IO[Unit] = files.createFile(path)
+
+    /**
+     * Creates the specified directory and any parent directories, using the
+     * supplied permissions for any directories that get created as a result of
+     * this operation. For example if `/a` exists and
+     * `createDirectories(Path("/a/b/c"), Some(p))` is called, `/a/b` and
+     * `/a/b/c` are created with permissions set to `p` on each (and the
+     * permissions of `/a` remain unmodified).
+     */
+    def createFile(permissions: Option[Permissions]): IO[Unit] =
+      files.createFile(path, permissions)
+
+    /** Creates a hard link with an existing file. */
+    def createLink(existing: Path): IO[Unit] = files.createLink(path, existing)
+
+    /** Creates a symbolic link which points to the supplied target. */
+    def createSymbolicLink(target: Path): IO[Unit] =
+      files.createSymbolicLink(path, target)
+
+    /**
+     * Creates a symbolic link which points to the supplied target with optional
+     * permissions.
+     */
+    def createSymbolicLink(
+        target: Path,
+        permissions: Option[Permissions]
+    ): IO[Unit] =
+      files.createSymbolicLink(path, target, permissions)
+
+    /**
+     * Deletes the file/directory if it exists, returning whether it was
+     * deleted.
+     */
+    def deleteIfExists: IO[Boolean] = files.deleteIfExists(path)
+
+    /** Deletes the file/directory recursively, following symbolic links. */
+    def deleteRecursively(followLinks: Boolean = false): IO[Unit] =
+      files.deleteRecursively(path, followLinks)
+
+    /** Returns true if the path exists, optionally following symbolic links. */
+    def exists(followLinks: Boolean = true): IO[Boolean] =
+      files.exists(path, followLinks)
+
+    /** Gets file attributes, optionally following symbolic links. */
+    def getBasicFileAttributes(
+        followLinks: Boolean = false
+    ): IO[BasicFileAttributes] =
+      files.getBasicFileAttributes(path, followLinks)
+
+    /**
+     * Gets POSIX file attributes, optionally following symbolic links (if
+     * available).
+     */
+    def getPosixFileAttributes(
+        followLinks: Boolean = false
+    ): IO[PosixFileAttributes] =
+      files.getPosixFileAttributes(
+        path,
+        followLinks
+      ) // Note: May fail on non-POSIX systems
+
+    /** Gets last modified time, optionally following symbolic links. */
+    def getLastModifiedTime(followLinks: Boolean = true): IO[FiniteDuration] =
+      files.getLastModifiedTime(path, followLinks)
+
+    /**
+     * Gets POSIX permissions, optionally following symbolic links (if
+     * available).
+     */
+    def getPosixPermissions(followLinks: Boolean = true): IO[PosixPermissions] =
+      files.getPosixPermissions(
+        path,
+        followLinks
+      ) // Note: May fail on non-POSIX systems
+
+    /**
+     * Checks if the path is a directory, optionally following symbolic links.
+     */
+    def isDirectory(followLinks: Boolean = true): IO[Boolean] =
+      files.isDirectory(path, followLinks)
+
+    def isExecutable: IO[Boolean] = files.isExecutable(path)
+    def isHidden: IO[Boolean]     = files.isHidden(path)
+    def isReadable: IO[Boolean]   = files.isReadable(path)
+
+    /**
+     * Checks if the path is a regular file, optionally following symbolic
+     * links.
+     */
+    def isRegularFile(followLinks: Boolean = true): IO[Boolean] =
+      files.isRegularFile(path, followLinks)
+
+    def isSymbolicLink: IO[Boolean] = files.isSymbolicLink(path)
+    def isWritable: IO[Boolean]     = files.isWritable(path)
+
+    /** Checks if this path references the same file as another. */
+    def isSameFile(other: Path): IO[Boolean] = files.isSameFile(path, other)
+
+    /** Gets the real path, resolving symbolic links. */
+    def realPath: IO[Path] = files.realPath(path)
+
+    /** Sets POSIX permissions (if supported). */
+    def setPosixPermissions(permissions: PosixPermissions): IO[Unit] =
+      files.setPosixPermissions(path, permissions)
+
+    /** Gets the size of the supplied path, failing if it does not exist. */
+    def size: IO[Long] = files.size(path)
+
+  }
+
+}

--- a/core/src/main/scala/io/chrisdavenport/shellfish/syntax/path/package.scala
+++ b/core/src/main/scala/io/chrisdavenport/shellfish/syntax/path/package.scala
@@ -232,10 +232,17 @@ package object path {
 
     /**
      * Copies the source to the target, failing if source does not exist or the
-     * target already exists. To replace the existing instead, use `copy(source,
-     * target, CopyFlags(CopyFlag.ReplaceExisting))`.
+     * target already exists. To replace the existing instead, use
+     * `source.copy(CopyFlags(CopyFlag.ReplaceExisting))(target)`.
      */
     def copy(to: Path): IO[Unit] = files.copy(path, to)
+
+    /**
+     * Copies the source to the target, following any directives supplied in the
+     * flags. By default, an error occurs if the target already exists, though
+     * this can be overriden via CopyFlag.ReplaceExisting.
+     */
+    def copy(flags: CopyFlags)(to: Path): IO[Unit] = files.copy(path, to, flags)
 
     /**
      * Creates the specified directory. Fails if the parent path does not

--- a/core/src/main/scala/io/chrisdavenport/shellfish/syntax/path/package.scala
+++ b/core/src/main/scala/io/chrisdavenport/shellfish/syntax/path/package.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2024 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package io.chrisdavenport.shellfish
 package syntax
 

--- a/core/src/main/scala/io/chrisdavenport/shellfish/syntax/path/package.scala
+++ b/core/src/main/scala/io/chrisdavenport/shellfish/syntax/path/package.scala
@@ -62,7 +62,7 @@ package object path {
      * @return
      *   The file loaded in memory as a String
      */
-    def readWithCharset(path: Path, charset: Charset): IO[String] =
+    def readWithCharset(charset: Charset): IO[String] =
       FilesOs.readWithCharset(path, charset)
 
     /**
@@ -206,7 +206,6 @@ package object path {
      *   The charset to use to encode the contents
      */
     def appendWithCharset(
-        path: Path,
         contents: String,
         charset: Charset
     ): IO[Unit] =

--- a/core/src/test/scala/io/chrisdavenport/shellfish/FileOsSpec.scala
+++ b/core/src/test/scala/io/chrisdavenport/shellfish/FileOsSpec.scala
@@ -89,6 +89,19 @@ object FileOsSpec extends SimpleIOSuite with Checkers {
     }
   }
 
+  test("Append should behave the same as adding at the end of the string") {
+    val temp = Files[IO].tempFile
+
+    temp.use { path =>
+      for {
+        before <- path.read
+        _      <- path.append(contents)
+        after  <- path.read
+        result = StringBuilder(before).append(contents).result()
+      } yield expect(result == after)
+    }
+  }
+
   test(
     "`readAs` and `writeAs` should encode and decode correctly with the same codec"
   ) {

--- a/core/src/test/scala/io/chrisdavenport/shellfish/FileOsSpec.scala
+++ b/core/src/test/scala/io/chrisdavenport/shellfish/FileOsSpec.scala
@@ -26,21 +26,15 @@ import weaver.scalacheck.Checkers
 
 import org.scalacheck.Gen
 
-import cats.effect.{IO, Resource}
+import cats.effect.Resource
 
-import fs2.io.file.{Files, CopyFlags}
-import fs2.io.file.CopyFlag
+import fs2.io.file.{CopyFlag, CopyFlags}
 
 import scodec.bits.ByteVector
 
 import syntax.path.*
 
-import weaver.scalacheck.CheckConfig
-
 object FileOsSpec extends SimpleIOSuite with Checkers {
-
-  override def checkConfig: CheckConfig =
-    super.checkConfig.copy(perPropertyParallelism = 1)
 
   test("The API should create and delete a file") {
     tempFile.use { path =>
@@ -53,7 +47,7 @@ object FileOsSpec extends SimpleIOSuite with Checkers {
 
   test("Copying a file should have the same content as the original") {
 
-    val temp = Resource.both(Files[IO].tempFile, Files[IO].tempFile)
+    val temp = Resource.both(tempFile, tempFile)
 
     forall(Gen.asciiStr) { contents =>
       temp.use { case (t1, t2) =>

--- a/core/src/test/scala/io/chrisdavenport/shellfish/FileOsSpec.scala
+++ b/core/src/test/scala/io/chrisdavenport/shellfish/FileOsSpec.scala
@@ -1,0 +1,91 @@
+package io.chrisdavenport.shellfish
+
+import weaver.SimpleIOSuite
+import weaver.scalacheck.Checkers
+
+import org.scalacheck.Gen
+
+import cats.effect.IO
+
+import fs2.io.file.{Path, Files}
+
+import syntax.path.*
+
+object FileOsSpec extends SimpleIOSuite with Checkers {
+
+  val stringGen: Gen[String] = Gen.asciiStr
+  val contents: String =
+    stringGen.sample.getOrElse("Can't gen the contents 🤷🏻‍♀️")
+
+  test("The API should create and delete a file") {
+    val t = Path("core/src/test/resources/temp.tmp")
+    for {
+      _       <- t.createFile
+      _       <- t.write(contents)
+      deleted <- t.deleteIfExists
+    } yield expect(deleted)
+  }
+
+  test("Copying a file should have the same content as the original") {
+
+    val t1 = Path("core/src/test/resources/temp1.tmp")
+    val t2 = Path("core/src/test/resources/temp2.tmp")
+
+    for {
+      _  <- t1.createFile
+      _  <- t1.write(contents)
+      _  <- t1.copy(t2)
+      s1 <- t1.read
+      s2 <- t2.read
+      _  <- t1.deleteIfExists
+      _  <- t2.deleteIfExists
+
+    } yield expect.same(s1, s2)
+  }
+
+  test(
+    "Append to a file using `append` should increate the size of the file in one"
+  ) {
+
+    val temp = Files[IO].tempFile
+    val contentGenerator =
+      Gen.size.flatMap(size => Gen.listOfN(size, stringGen))
+    val contentsList =
+      contentGenerator.sample.getOrElse(List("Can't gen the contents 🤷🏻‍♀️"))
+
+    temp.use { path =>
+      for {
+        _          <- path.writeLines(contentsList.toVector)
+        sizeBefore <- path.readLines.map(_.size)
+        _          <- path.append("\nIm a last line!")
+        sizeAfter  <- path.readLines.map(_.size)
+      } yield expect(sizeBefore + 1 == sizeAfter)
+
+    }
+  }
+
+  test(
+    "`readAs` and `writeAs` should encode and decode correctly with the same codec"
+  ) {
+    val temp           = Files[IO].tempFile
+    implicit val codec = scodec.codecs.utf8
+
+    temp.use { path =>
+      for {
+        _    <- path.writeAs(contents)
+        file <- path.readAs[String]
+      } yield expect.same(contents, file)
+    }
+  }
+
+  test("We should write bytes and read bytes") {
+    val temp  = Files[IO].tempFile
+    val bytes = scodec.bits.ByteVector(contents.getBytes())
+    temp.use { path =>
+      for {
+        _    <- path.writeBytes(bytes)
+        file <- path.readBytes
+      } yield expect.same(bytes, file)
+    }
+  }
+}

--- a/core/src/test/scala/io/chrisdavenport/shellfish/FileOsSpec.scala
+++ b/core/src/test/scala/io/chrisdavenport/shellfish/FileOsSpec.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2024 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package io.chrisdavenport.shellfish
 
 import weaver.SimpleIOSuite

--- a/core/src/test/scala/io/chrisdavenport/shellfish/MainSpec.scala
+++ b/core/src/test/scala/io/chrisdavenport/shellfish/MainSpec.scala
@@ -47,13 +47,15 @@ object MainSpec extends SimpleIOSuite {
   test("We should be able to create and delete a directory") {
     val td = Path("core/src/test/resources/tempDir")
 
-    for {
-      before  <- pwd
-      _       <- td.createDirectory
-      _       <- cd(td.toString)
-      current <- pwd
-      deleted <- td.deleteIfExists
-    } yield expect(Path(current) == (Path(before) / td) && deleted)
+    tempDirectory.use { dir =>
+      for {
+        before  <- pwd
+        _       <- dir.createDirectory
+        _       <- cd(td.toString)
+        current <- pwd
+        deleted <- td.deleteIfExists
+      } yield expect(Path(current) == (Path(before) / td) && deleted)
+    }
   }
 
 }

--- a/core/src/test/scala/io/chrisdavenport/shellfish/MainSpec.scala
+++ b/core/src/test/scala/io/chrisdavenport/shellfish/MainSpec.scala
@@ -21,12 +21,39 @@
 
 package io.chrisdavenport.shellfish
 
-import munit.CatsEffectSuite
+import weaver.SimpleIOSuite
 
-class MainSpec extends CatsEffectSuite {
+import fs2.io.file.Path
 
-  test("Main should exit succesfully") {
-    assert(clue(1) == clue(1))
+import syntax.path.*
+
+object MainSpec extends SimpleIOSuite {
+
+  import Shell.io.{cd, pwd}
+
+  pureTest("Main should exit successfully") {
+    expect(1 == 1)
+  }
+
+  test("cd should some back and forth") {
+    for {
+      current  <- pwd
+      _        <- cd("..")
+      _        <- cd(current)
+      current2 <- pwd
+    } yield expect(current == current2)
+  }
+
+  test("We should be able to create and delete a directory") {
+    val td = Path("core/src/test/resources/tempDir")
+
+    for {
+      before  <- pwd
+      _       <- td.createDirectory
+      _       <- cd(td.toString)
+      current <- pwd
+      deleted <- td.deleteIfExists
+    } yield expect(Path(current) == (Path(before) / td) && deleted)
   }
 
 }

--- a/core/src/test/scala/io/chrisdavenport/shellfish/MainSpec.scala
+++ b/core/src/test/scala/io/chrisdavenport/shellfish/MainSpec.scala
@@ -23,8 +23,6 @@ package io.chrisdavenport.shellfish
 
 import weaver.SimpleIOSuite
 
-import fs2.io.file.Path
-
 import syntax.path.*
 
 object MainSpec extends SimpleIOSuite {
@@ -45,17 +43,13 @@ object MainSpec extends SimpleIOSuite {
   }
 
   test("We should be able to create and delete a directory") {
-    val td = Path("core/src/test/resources/tempDir")
 
-    tempDirectory.use { dir =>
-      for {
-        before  <- pwd
-        _       <- dir.createDirectory
-        _       <- cd(td.toString)
-        current <- pwd
-        deleted <- td.deleteIfExists
-      } yield expect(Path(current) == (Path(before) / td) && deleted)
-    }
+    for {
+      home <- userHome
+      dir = home / "shellfish"
+      _       <- dir.createDirectory
+      exists  <- dir.exists
+      deleted <- dir.deleteIfExists
+    } yield expect(exists && deleted)
   }
-
 }

--- a/core/src/test/scala/io/chrisdavenport/shellfish/SyntaxSpec.scala
+++ b/core/src/test/scala/io/chrisdavenport/shellfish/SyntaxSpec.scala
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2024 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.chrisdavenport.shellfish
+
+import weaver.SimpleIOSuite
+import weaver.scalacheck.Checkers
+
+import org.scalacheck.Gen
+
+import syntax.path.*
+
+object SyntaxSpec extends SimpleIOSuite with Checkers {
+
+  test(
+    "Extension methods for read, write and append should work the same as the normal ones"
+  ) {
+    forall(Gen.asciiStr) { contents =>
+      tempFile.use { path =>
+        for {
+          _  <- path.write(contents)
+          _  <- path.append("Hi from the test!")
+          s1 <- path.read
+          _  <- FilesOs.write(path, contents)
+          _  <- FilesOs.append(path, "Hi from the test!")
+          s2 <- FilesOs.read(path)
+        } yield expect.same(s1, s2)
+      }
+    }
+  }
+
+  test(
+    "Extension methods for creating and deleting a file should work the same as the normal ones"
+  ) {
+    tempDirectory.use { dir =>
+      val path = dir / "sample.txt"
+      for {
+        _        <- path.createFile
+        exists   <- path.exists
+        deleted  <- path.deleteIfExists
+        _        <- FilesOs.createFile(path)
+        exists2  <- FilesOs.exists(path)
+        deleted2 <- FilesOs.deleteIfExists(path)
+      } yield expect(exists && deleted) and expect(exists2 && deleted2)
+    }
+  }
+
+  test(
+    "Extension methods for copying a file should work the same as the normal ones"
+  ) {
+    forall(Gen.asciiStr) { contents =>
+      tempDirectory.use { dir =>
+        val original = dir / "sample.txt"
+        val copy1    = dir / "sample-copy.txt"
+        val copy2    = dir / "sample-copy-jo2.txt"
+        for {
+          _  <- original.write(contents)
+          _  <- original.copy(copy1)
+          _  <- FilesOs.copy(original, copy2)
+          s1 <- copy1.read
+          s2 <- copy2.read
+        } yield expect.same(s1, s2)
+      }
+    }
+  }
+
+  test(
+    "Extension methods for moving a file should work the same as the normal ones"
+  ) {
+
+    forall(Gen.asciiStr) { contents =>
+      tempDirectory.use { dir =>
+        val original = dir / "sample.txt"
+        val moved    = dir / "sample-moved.txt"
+        for {
+          _      <- original.write(contents)
+          _      <- original.move(moved)
+          exists <- moved.exists
+
+          _ <- moved.delete
+
+          _       <- FilesOs.write(original, contents)
+          _       <- FilesOs.move(original, moved)
+          exists2 <- moved.exists
+        } yield expect(exists && exists2)
+      }
+    }
+  }
+
+}

--- a/docs/examples/directory.conf
+++ b/docs/examples/directory.conf
@@ -1,0 +1,4 @@
+laika.title = Examples
+laika.navigationOrder = [
+  index.md
+]

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -1,6 +1,6 @@
 # Examples
 
-We understand that learning a new library is easiest through hands-on experience. That's why we've created the "Examples" section. Here you'll find a curated collection of code examples that show the library in action. These are some code snippets that show how to use many of the methods. You can also find these examples in the module `examples` on the project on our GitHub!
+Here you'll find a curated collection of code examples that show the library in action. 
 
 ## Scores
 ``` scala 3 mdoc

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -1,0 +1,94 @@
+# Examples
+
+We understand that learning a new library is easiest through hands-on experience. That's why we've created the "Examples" section. Here you'll find a curated collection of code examples that show the library in action. These are some code snippets that show how to use many of the methods. You can also find these examples in the module `examples` on the project on our GitHub!
+
+## Scores
+``` scala 3 mdoc
+import cats.syntax.all.*
+import cats.effect.{IO, IOApp}
+import fs2.io.file.Path
+
+import shellfish.os.syntax.path.*
+
+object Scores extends IOApp.Simple:
+
+  case class Score(name: String, score: Int):
+    def show: String = s"$name:$score"
+
+  def parseScore(strScore: String): Either[Throwable, Score] =
+    Either.catchNonFatal(
+      strScore.split(':') match 
+        case Array(name, score) => Score(name, score.toInt)
+        case _                  => Score("Cant parse this score", -1)
+    )
+
+  val path = Path("src/main/resources/scores.txt")
+
+  def run: IO[Unit] =
+    for
+      lines  <- path.readLines
+      scores <- lines.traverse(parseScore(_).liftTo[IO])
+      _      <- IO(scores.foreach(score => println(score.show)))
+      _      <- path.appendLine(Score("daniela", 100).show)
+    yield ()
+
+end Scores
+```
+
+## Uppercase
+``` scala 3 mdoc
+import cats.effect.{IO, IOApp}
+import fs2.io.file.Path
+
+import shellfish.os.syntax.path.*
+
+object Uppercase extends IOApp.Simple:
+
+  val path      = Path("src/main/resources/quijote.txt")
+  val upperPath = Path("src/main/resources/quijote_screaming.txt")
+
+  def run: IO[Unit] =
+    for
+      file <- path.read
+      _    <- upperPath.write(file.toUpperCase)
+    yield ()
+
+end Uppercase
+
+```
+
+## Places
+
+Shellfish OS has compatibility for working with scodecs!
+
+``` scala 3 mdoc
+import cats.syntax.applicative.*
+import cats.effect.{IO, IOApp}
+
+import fs2.io.file.Path
+
+import scodec.codecs.*
+import scodec.Codec
+
+import shellfish.os.syntax.path.*
+
+object Place extends IOApp.Simple:
+
+  case class Place(number: Int, name: String) derives Codec
+
+  // Only in Scala 2:
+  // implicit val placeCodec: Codec[Place] = (int32 :: utf8).as[Place]
+
+  val path = Path("src/main/resources/place.data")
+
+  def run: IO[Unit] =
+    for
+      exists <- path.exists
+           // Equivalent of doing `if (exists) IO.unit else path.createFile`
+      _ <- path.createFile.whenA(exists)
+      _ <- path.writeAs[Place](Place(1, "Michael Phelps"))
+      _ <- path.readAs[Place].flatMap(IO.println)
+    yield ()
+
+end Place
+```

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -59,7 +59,7 @@ end Uppercase
 
 ## Places
 
-Shellfish OS has compatibility for working with scodecs!
+Shellfish OS has compatibility for working with [scodec](https://scodec.org/)!
 
 ``` scala 3 mdoc
 import cats.syntax.applicative.*

--- a/examples/src/main/resources/quijote.txt
+++ b/examples/src/main/resources/quijote.txt
@@ -1,0 +1,73 @@
+El ingenioso hidalgo don Quijote de la Mancha
+
+
+TASA
+
+Yo, Juan Gallo de Andrada, escribano de Cámara del Rey nuestro señor, de
+los que residen en su Consejo, certifico y doy fe que, habiendo visto por
+los señores dél un libro intitulado El ingenioso hidalgo de la Mancha,
+compuesto por Miguel de Cervantes Saavedra, tasaron cada pliego del dicho
+libro a tres maravedís y medio; el cual tiene ochenta y tres pliegos, que
+al dicho precio monta el dicho libro docientos y noventa maravedís y medio,
+en que se ha de vender en papel; y dieron licencia para que a este precio
+se pueda vender, y mandaron que esta tasa se ponga al principio del dicho
+libro, y no se pueda vender sin ella. Y, para que dello conste, di la
+presente en Valladolid, a veinte días del mes de deciembre de mil y
+seiscientos y cuatro años.
+
+Juan Gallo de Andrada.
+
+TESTIMONIO DE LAS ERRATAS
+
+Este libro no tiene cosa digna que no corresponda a su original; en
+testimonio de lo haber correcto, di esta fee. En el Colegio de la Madre de
+Dios de los Teólogos de la Universidad de Alcalá, en primero de diciembre
+de 1604 años.
+
+El licenciado Francisco Murcia de la Llana.
+
+EL REY
+
+Por cuanto por parte de vos, Miguel de Cervantes, nos fue fecha relación
+que habíades compuesto un libro intitulado El ingenioso hidalgo de la
+Mancha, el cual os había costado mucho trabajo y era muy útil y provechoso,
+nos pedistes y suplicastes os mandásemos dar licencia y facultad para le
+poder imprimir, y previlegio por el tiempo que fuésemos servidos, o como la
+nuestra merced fuese; lo cual visto por los del nuestro Consejo, por cuanto
+en el dicho libro se hicieron las diligencias que la premática últimamente
+por nos fecha sobre la impresión de los libros dispone, fue acordado que
+debíamos mandar dar esta nuestra cédula para vos, en la dicha razón; y nos
+tuvímoslo por bien. Por la cual, por os hacer bien y merced, os damos
+licencia y facultad para que vos, o la persona que vuestro poder hubiere, y
+no otra alguna, podáis imprimir el dicho libro, intitulado El ingenioso
+hidalgo de la Mancha, que desuso se hace mención, en todos estos nuestros
+reinos de Castilla, por tiempo y espacio de diez años, que corran y se
+cuenten desde el dicho día de la data desta nuestra cédula; so pena que la
+persona o personas que, sin tener vuestro poder, lo imprimiere o vendiere,
+o hiciere imprimir o vender, por el mesmo caso pierda la impresión que
+hiciere, con los moldes y aparejos della; y más, incurra en pena de
+cincuenta mil maravedís cada vez que lo contrario hiciere. La cual dicha
+pena sea la tercia parte para la persona que lo acusare, y la otra tercia
+parte para nuestra Cámara, y la otra tercia parte para el juez que lo
+sentenciare. Con tanto que todas las veces que hubiéredes de hacer imprimir
+el dicho libro, durante el tiempo de los dichos diez años, le traigáis al
+nuestro Consejo, juntamente con el original que en él fue visto, que va
+rubricado cada plana y firmado al fin dél de Juan Gallo de Andrada, nuestro
+Escribano de Cámara, de los que en él residen, para saber si la dicha
+impresión está conforme el original; o traigáis fe en pública forma de cómo
+por corretor nombrado por nuestro mandado, se vio y corrigió la dicha
+impresión por el original, y se imprimió conforme a él, y quedan impresas
+las erratas por él apuntadas, para cada un libro de los que así fueren
+impresos, para que se tase el precio que por cada volume hubiéredes de
+haber. Y mandamos al impresor que así imprimiere el dicho libro, no imprima
+el principio ni el primer pliego dél, ni entregue más de un solo libro con
+el original al autor, o persona a cuya costa lo imprimiere, ni otro alguno,
+para efeto de la dicha correción y tasa, hasta que antes y primero el dicho
+libro esté corregido y tasado por los del nuestro Consejo; y, estando
+hecho, y no de otra manera, pueda imprimir el dicho principio y primer
+pliego, y sucesivamente ponga esta nuestra cédula y la aprobación, tasa y
+erratas, so pena de caer e incurrir en las penas contenidas en las leyes y
+premáticas destos nuestros reinos. Y mandamos a los del nuestro Consejo, y
+a otras cualesquier justicias dellos, guarden y cumplan esta nuestra cédula
+y lo en ella contenido. Fecha en Valladolid, a veinte y seis días del mes
+de setiembre de mil y seiscientos y cuatro años.

--- a/examples/src/main/resources/scores.txt
+++ b/examples/src/main/resources/scores.txt
@@ -1,0 +1,6 @@
+michel:21839
+zeta:9929
+thanh:20933
+tonio:12340
+arman:6969
+gabriel:32123

--- a/examples/src/main/scala/io/chrisdavenport/shellfish/Place.scala
+++ b/examples/src/main/scala/io/chrisdavenport/shellfish/Place.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2024 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package io.chrisdavenport.shellfish
 
 import cats.effect.{IO, IOApp}

--- a/examples/src/main/scala/io/chrisdavenport/shellfish/Place.scala
+++ b/examples/src/main/scala/io/chrisdavenport/shellfish/Place.scala
@@ -27,7 +27,7 @@ import cats.effect.{IO, IOApp}
 import scodec.codecs.*
 import scodec.Codec
 
-import syntax.path.*
+import io.chrisdavenport.shellfish.syntax.path.*
 import fs2.io.file.Path
 
 object Place extends IOApp.Simple {
@@ -40,11 +40,11 @@ object Place extends IOApp.Simple {
 
   def run: IO[Unit] =
     for {
-      exists <- path.exists()
-                // Equivalent of doing `if (exists) IO.unit else path.createFile` 
-      _      <- path.createFile.whenA(exists) 
-      _      <- path.writeAs[Place](Place(1, "Michael Phelps"))
-      _      <- path.readAs[Place].flatMap(IO.println)
+      exists <- path.exists
+           // Equivalent of doing `if (exists) IO.unit else path.createFile`
+      _ <- path.createFile.whenA(exists)
+      _ <- path.writeAs[Place](Place(1, "Michael Phelps"))
+      _ <- path.readAs[Place].flatMap(IO.println)
     } yield ()
 
 }

--- a/examples/src/main/scala/io/chrisdavenport/shellfish/Place.scala
+++ b/examples/src/main/scala/io/chrisdavenport/shellfish/Place.scala
@@ -1,0 +1,27 @@
+package io.chrisdavenport.shellfish
+
+import cats.effect.{IO, IOApp}
+
+import scodec.codecs.*
+import scodec.Codec
+
+import syntax.path.*
+import fs2.io.file.Path
+
+object Place extends IOApp.Simple {
+
+  case class Place(number: Int, name: String)
+
+  implicit val placeCodec: Codec[Place] = (int32 :: utf8).as[Place]
+
+  val path = Path("src/main/resources/place.data")
+
+  def run: IO[Unit] =
+    for {
+      exists <- path.exists()
+      _      <- if (exists) IO.unit else path.createFile
+      _      <- path.writeAs[Place](Place(1, "Michael Phelps"))
+      _      <- path.readAs[Place].flatMap(p => IO.println(p))
+    } yield ()
+
+}

--- a/examples/src/main/scala/io/chrisdavenport/shellfish/Place.scala
+++ b/examples/src/main/scala/io/chrisdavenport/shellfish/Place.scala
@@ -41,7 +41,7 @@ object Place extends IOApp.Simple {
   def run: IO[Unit] =
     for {
       exists <- path.exists
-           // Equivalent of doing `if (exists) IO.unit else path.createFile`
+      // Equivalent of doing `if (exists) IO.unit else path.createFile`
       _ <- path.createFile.whenA(exists)
       _ <- path.writeAs[Place](Place(1, "Michael Phelps"))
       _ <- path.readAs[Place].flatMap(IO.println)

--- a/examples/src/main/scala/io/chrisdavenport/shellfish/Place.scala
+++ b/examples/src/main/scala/io/chrisdavenport/shellfish/Place.scala
@@ -41,7 +41,8 @@ object Place extends IOApp.Simple {
   def run: IO[Unit] =
     for {
       exists <- path.exists()
-      _      <- path.createFile.whenA(exists)  
+                // Equivalent of doing `if (exists) IO.unit else path.createFile` 
+      _      <- path.createFile.whenA(exists) 
       _      <- path.writeAs[Place](Place(1, "Michael Phelps"))
       _      <- path.readAs[Place].flatMap(IO.println)
     } yield ()

--- a/examples/src/main/scala/io/chrisdavenport/shellfish/Place.scala
+++ b/examples/src/main/scala/io/chrisdavenport/shellfish/Place.scala
@@ -21,6 +21,7 @@
 
 package io.chrisdavenport.shellfish
 
+import cats.syntax.applicative.*
 import cats.effect.{IO, IOApp}
 
 import scodec.codecs.*
@@ -40,9 +41,9 @@ object Place extends IOApp.Simple {
   def run: IO[Unit] =
     for {
       exists <- path.exists()
-      _      <- if (exists) IO.unit else path.createFile
+      _      <- path.createFile.whenA(exists)  
       _      <- path.writeAs[Place](Place(1, "Michael Phelps"))
-      _      <- path.readAs[Place].flatMap(p => IO.println(p))
+      _      <- path.readAs[Place].flatMap(IO.println)
     } yield ()
 
 }

--- a/examples/src/main/scala/io/chrisdavenport/shellfish/Scores.scala
+++ b/examples/src/main/scala/io/chrisdavenport/shellfish/Scores.scala
@@ -1,0 +1,33 @@
+package io.chrisdavenport.shellfish
+
+import cats.syntax.all.*
+import cats.effect.{IO, IOApp}
+
+import fs2.io.file.*
+
+import io.chrisdavenport.shellfish.syntax.path.*
+
+object Scores extends IOApp.Simple {
+
+  case class Score(name: String, score: Int) {
+    def show: String = s"$name:$score"
+  }
+
+  def parseScore(strScore: String): Either[Throwable, Score] =
+    Either.catchNonFatal(
+      strScore.split(':') match {
+        case Array(name, score) => Score(name, score.toInt)
+        case _                  => Score("Cant parse this score", -1)
+      }
+    )
+
+  val path = Path("src/main/resources/scores.txt")
+  override def run: IO[Unit] =
+    for {
+      lines  <- path.readLines
+      scores <- lines.map(parseScore(_).liftTo[IO]).sequence
+      _      <- IO(scores.foreach(score => println(score.show)))
+      bytes  <- path.append(s"\n${Score("daniela", 100).show}")
+      _      <- IO.println(s"Successfully written $bytes bytes.")
+    } yield ()
+}

--- a/examples/src/main/scala/io/chrisdavenport/shellfish/Scores.scala
+++ b/examples/src/main/scala/io/chrisdavenport/shellfish/Scores.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2024 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package io.chrisdavenport.shellfish
 
 import cats.syntax.all.*

--- a/examples/src/main/scala/io/chrisdavenport/shellfish/Scores.scala
+++ b/examples/src/main/scala/io/chrisdavenport/shellfish/Scores.scala
@@ -46,7 +46,7 @@ object Scores extends IOApp.Simple {
   override def run: IO[Unit] =
     for {
       lines  <- path.readLines
-      scores <- lines.map(parseScore(_).liftTo[IO]).sequence
+      scores <- lines.traverse(parseScore(_).liftTo[IO]) 
       _      <- IO(scores.foreach(score => println(score.show)))
       bytes  <- path.append(s"\n${Score("daniela", 100).show}")
       _      <- IO.println(s"Successfully written $bytes bytes.")

--- a/examples/src/main/scala/io/chrisdavenport/shellfish/Scores.scala
+++ b/examples/src/main/scala/io/chrisdavenport/shellfish/Scores.scala
@@ -24,7 +24,7 @@ package io.chrisdavenport.shellfish
 import cats.syntax.all.*
 import cats.effect.{IO, IOApp}
 
-import fs2.io.file.*
+import fs2.io.file.Path
 
 import io.chrisdavenport.shellfish.syntax.path.*
 
@@ -46,9 +46,8 @@ object Scores extends IOApp.Simple {
   override def run: IO[Unit] =
     for {
       lines  <- path.readLines
-      scores <- lines.traverse(parseScore(_).liftTo[IO]) 
+      scores <- lines.traverse(parseScore(_).liftTo[IO])
       _      <- IO(scores.foreach(score => println(score.show)))
-      bytes  <- path.append(s"\n${Score("daniela", 100).show}")
-      _      <- IO.println(s"Successfully written $bytes bytes.")
+      _      <- path.append(Score("daniela", 100).show)
     } yield ()
 }

--- a/examples/src/main/scala/io/chrisdavenport/shellfish/Uppercase.scala
+++ b/examples/src/main/scala/io/chrisdavenport/shellfish/Uppercase.scala
@@ -1,0 +1,18 @@
+package io.chrisdavenport.shellfish
+
+import cats.effect.{IO, IOApp}
+import fs2.io.file.Path
+import syntax.path.*
+
+object Uppercase extends IOApp.Simple {
+
+  val path      = Path("src/main/resources/quijote.txt")
+  val upperPath = Path("src/main/resources/quijote_screaming.txt")
+
+  def run: IO[Unit] =
+    for {
+      file <- path.read
+      _    <- upperPath.write(file.toUpperCase)
+    } yield ()
+
+}

--- a/examples/src/main/scala/io/chrisdavenport/shellfish/Uppercase.scala
+++ b/examples/src/main/scala/io/chrisdavenport/shellfish/Uppercase.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2024 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package io.chrisdavenport.shellfish
 
 import cats.effect.{IO, IOApp}


### PR DESCRIPTION
Works on #63 

It creates a `FilesOs` object to access the most common read and write operations in scripting.

It has three main operations, `read`, `write` and `append`, each of them with four different variants: Standalone, `Bytes`, `Lines` and `As`, to be able to read, write or append either as a whole string, a `ByteVector`, a vector of string lines, or as a generic type A given a `Codec[A]`. There are also two functions to load the file as a `Stream[IO, Byte]` or as a `Chunk[Byte]`.

There are also a bunch of extension methods that work over `fs2.io.files.Path` to handle the previous operations, as well as some of the Files[F] typeclass API (the API coverage is not at its 100% just jet, but it includes the most important ones such as creating files or directories, copying, and deleting). The extension methods are imported using `import syntax.path.*`

In this way, you can use the API in two different ways: 

**Using the `FilesOs` object:**

```scala
val path = Path("path/to/file/hi.txt")
for 
  file <- FilesOs.read(path)
  _ <- IO.println(file)
  _ <- FilesOs.write(path, file + "\nEnd of the file!")
yield ()
```

**Using extension methods:**
```scala
import syntax.path.*
val path = Path("path/to/file/hi.txt")
for 
  file <- path.read
  _ <- IO.println(file)
  _ <- path.write(file + "\nEnd of the file!")
yield ()
```

Testing is also added.

This PR also adds some examples under the module `examples` (if you got more in mind they are very welcome so I can place them ☺️).

Other minor changes.
