### PR TITLE
Discussion: Simplify the API for newcomers 

### DIFF
--- a/core/src/main/scala/io/chrisdavenport/shellfish/FilesOs.scala
+++ b/core/src/main/scala/io/chrisdavenport/shellfish/FilesOs.scala
@@ -681,7 +681,7 @@ object FilesOs {
   /**
    * Creates a temporary file and deletes it at the end of the use of it.
    */
-  def tempFile[A](use: Path => IO[A]): IO[A] =
+  def withTempFile[A](use: Path => IO[A]): IO[A] =
     files.tempFile.use(use)
 
   /**
@@ -702,7 +702,7 @@ object FilesOs {
    * @return
    *   The result of the computation after using the temporary file
    */
-  def tempFile[A](
+  def withTempFile[A](
       dir: Option[Path],
       prefix: String,
       suffix: String,
@@ -713,7 +713,7 @@ object FilesOs {
   /**
    * Creates a temporary directory and deletes it at the end of the use of it.
    */
-  def tempDirectory[A](use: Path => IO[A]): IO[A] =
+  def withTempDirectory[A](use: Path => IO[A]): IO[A] =
     files.tempDirectory.use(use)
 
   /**
@@ -732,7 +732,7 @@ object FilesOs {
    * @return
    *   the result of the computation after using the temporary directory
    */
-  def tempDirectory[A](
+  def withTempDirectory[A](
       dir: Option[Path],
       prefix: String,
       permissions: Permissions

--- a/core/src/main/scala/io/chrisdavenport/shellfish/syntax/path/package.scala
+++ b/core/src/main/scala/io/chrisdavenport/shellfish/syntax/path/package.scala
@@ -22,9 +22,8 @@
 package io.chrisdavenport.shellfish
 package syntax
 
-import cats.effect.{IO, Resource}
+import cats.effect.IO
 
-import fs2.Stream
 import fs2.io.file.*
 
 import scodec.bits.ByteVector
@@ -474,7 +473,7 @@ package object path {
     def isSameFile(path2: Path): IO[Boolean] = FilesOs.isSameFile(path, path2)
 
     /** Gets the contents of the specified directory. */
-    def list: Stream[IO, Path] = FilesOs.list(path)
+    def list: IO[List[Path]] = FilesOs.list(path)
 
     /**
      * Moves the source to the target, failing if source does not exist or the
@@ -490,17 +489,6 @@ package object path {
      */
     def move(target: Path, flags: CopyFlags): IO[Unit] =
       FilesOs.move(path, target, flags)
-
-    /** Creates a `FileHandle` for the file at the supplied `Path`. */
-    def open(flags: Flags): Resource[IO, FileHandle[IO]] =
-      FilesOs.open(path, flags)
-
-    /**
-     * Returns a `ReadCursor` for the specified path, using the supplied flags
-     * when opening the file.
-     */
-    def readCursor(flags: Flags): Resource[IO, ReadCursor[IO]] =
-      FilesOs.readCursor(path, flags)
 
     // Real Path
     /** Returns the real path i.e. the actual location of `path`. */

--- a/core/src/main/scala/io/chrisdavenport/shellfish/syntax/path/package.scala
+++ b/core/src/main/scala/io/chrisdavenport/shellfish/syntax/path/package.scala
@@ -22,7 +22,6 @@
 package io.chrisdavenport.shellfish
 package syntax
 
-import cats.syntax.all.*
 import cats.effect.{IO, Resource}
 
 import fs2.Stream

--- a/core/src/main/scala/io/chrisdavenport/shellfish/syntax/path/package.scala
+++ b/core/src/main/scala/io/chrisdavenport/shellfish/syntax/path/package.scala
@@ -596,8 +596,8 @@ package object path {
   /**
    * Creates a temporary file and deletes it at the end of the use of it.
    */
-  def tempFile[A](use: Path => IO[A]): IO[A] =
-    FilesOs.tempFile(use)
+  def withTempFile[A](use: Path => IO[A]): IO[A] =
+    FilesOs.withTempFile(use)
 
   /**
    * Creates a temporary file and deletes it at the end of the use of it.
@@ -617,18 +617,19 @@ package object path {
    * @return
    *   The result of the computation after using the temporary file
    */
-  def tempFile[A](
+  def withTempFile[A](
       dir: Option[Path],
       prefix: String,
       suffix: String,
       permissions: Permissions
   )(use: Path => IO[A]): IO[A] =
-    FilesOs.tempFile(dir, prefix, suffix, permissions)(use)
+    FilesOs.withTempFile(dir, prefix, suffix, permissions)(use)
 
   /**
    * Creates a temporary directory and deletes it at the end of the use of it.
    */
-  def tempDirectory[A](use: Path => IO[A]): IO[A] = FilesOs.tempDirectory(use)
+  def withTempDirectory[A](use: Path => IO[A]): IO[A] =
+    FilesOs.withTempDirectory(use)
 
   /**
    * Creates a temporary directory and deletes it at the end of the use of it.
@@ -646,12 +647,12 @@ package object path {
    * @return
    *   the result of the computation after using the temporary directory
    */
-  def tempDirectory[A](
+  def withTempDirectory[A](
       dir: Option[Path],
       prefix: String,
       permissions: Permissions
   )(use: Path => IO[A]): IO[A] =
-    FilesOs.tempDirectory(dir, prefix, permissions)(use)
+    FilesOs.withTempDirectory(dir, prefix, permissions)(use)
 
   /** User's home directory */
   def userHome: IO[Path] = files.userHome

--- a/core/src/test/scala/io/chrisdavenport/shellfish/FileOsSpec.scala
+++ b/core/src/test/scala/io/chrisdavenport/shellfish/FileOsSpec.scala
@@ -40,7 +40,7 @@ import syntax.path.*
 object FileOsSpec extends SimpleIOSuite with Checkers {
 
   test("The API should delete a file") {
-    tempFile { path =>
+    withTempFile { path =>
       for {
         _       <- path.write("")
         deleted <- path.deleteIfExists
@@ -50,8 +50,8 @@ object FileOsSpec extends SimpleIOSuite with Checkers {
 
   test("Copying a file should have the same content as the original") {
     forall(Gen.asciiStr) { contents =>
-      tempFile { t1 =>
-        tempFile { t2 =>
+      withTempFile { t1 =>
+        withTempFile { t2 =>
           for {
             _  <- t1.write(contents)
             _  <- t1.copy(t2, CopyFlags(CopyFlag.ReplaceExisting))
@@ -74,7 +74,7 @@ object FileOsSpec extends SimpleIOSuite with Checkers {
       Gen.size.flatMap(size => Gen.listOfN(size, Gen.asciiStr))
 
     forall(contentGenerator) { contentsList =>
-      tempFile { path =>
+      withTempFile { path =>
         for {
           _          <- path.writeLines(contentsList)
           sizeBefore <- path.readLines.map(_.size)
@@ -87,7 +87,7 @@ object FileOsSpec extends SimpleIOSuite with Checkers {
 
   test("Append should behave the same as adding at the end of the string") {
     forall(Gen.asciiStr) { contents =>
-      tempFile { path =>
+      withTempFile { path =>
         for {
           _          <- path.write(contents)
           sizeBefore <- path.read.map(_.length)
@@ -102,8 +102,8 @@ object FileOsSpec extends SimpleIOSuite with Checkers {
     "`append` should behave the same as `appendLine` when prepending a newline to the contents"
   ) {
     forall(Gen.asciiStr) { contents =>
-      tempFile { t1 =>
-        tempFile { t2 =>
+      withTempFile { t1 =>
+        withTempFile { t2 =>
           for {
             _     <- t1.append(s"\n$contents")
             _     <- t2.appendLine(contents)
@@ -121,7 +121,7 @@ object FileOsSpec extends SimpleIOSuite with Checkers {
     implicit val codec: Codec[String] = scodec.codecs.ascii
 
     forall(Gen.asciiStr) { contents =>
-      tempFile { path =>
+      withTempFile { path =>
         for {
           _          <- path.writeAs(contents)
           sizeBefore <- path.read.map(_.length)
@@ -135,7 +135,7 @@ object FileOsSpec extends SimpleIOSuite with Checkers {
   test("We should write bytes and read bytes") {
 
     forall(Gen.identifier) { name =>
-      tempFile { path =>
+      withTempFile { path =>
         val bytes = ByteVector(name.getBytes)
 
         for {
@@ -163,7 +163,7 @@ object FileOsSpec extends SimpleIOSuite with Checkers {
       } yield (path, contents)
 
     forall(multipleGenerators) { case (path, contents) =>
-      tempDirectory { dir =>
+      withTempDirectory { dir =>
         val firstPath = dir / "moving_file.data"
         val movePath  = dir / path / "moved_file.data"
 
@@ -187,7 +187,7 @@ object FileOsSpec extends SimpleIOSuite with Checkers {
       Gen.size.flatMap(size => Gen.listOfN(size, Gen.asciiStr))
 
     forall(contentGenerator) { contentsList =>
-      tempFile { path =>
+      withTempFile { path =>
         for {
           _          <- path.writeLines(contentsList)
           size       <- path.size
@@ -206,7 +206,7 @@ object FileOsSpec extends SimpleIOSuite with Checkers {
       } yield names.foldLeft(Path(""))(_ / _)
 
     forall(pathsGenerator) { paths =>
-      tempDirectory { dir =>
+      withTempDirectory { dir =>
         val tempDir = dir / paths
 
         for {
@@ -221,7 +221,7 @@ object FileOsSpec extends SimpleIOSuite with Checkers {
 
   test("We should be able to get and modify the last modified time of a file") {
     forall(Gen.asciiStr) { contents =>
-      tempFile { path =>
+      withTempFile { path =>
         for {
           _      <- path.write(contents)
           before <- path.getLastModifiedTime
@@ -251,8 +251,8 @@ object FileOsSpec extends SimpleIOSuite with Checkers {
       } yield names.foldLeft(Path(""))(_ / _)
 
     forall(pathsGenerator) { path =>
-      tempFile { file =>
-        tempDirectory { dir =>
+      withTempFile { file =>
+        withTempDirectory { dir =>
           val link = dir / path / "link"
           for {
             _           <- (dir / path).createDirectories
@@ -273,7 +273,7 @@ object FileOsSpec extends SimpleIOSuite with Checkers {
 
   // Warning: Platform dependent test; this may fail on some operating systems
   test("The permissions POSIX API should approve or prevent reading") {
-    tempFile { path =>
+    withTempFile { path =>
       for {
         _ <- path.setPosixPermissions(
           PosixPermissions.fromString("r--r--r--").get
@@ -290,7 +290,7 @@ object FileOsSpec extends SimpleIOSuite with Checkers {
 
   // Warning: Platform dependent test; this may fail on some operating systems
   test("The permissions POSIX API should approve or prevent writing") {
-    tempFile { path =>
+    withTempFile { path =>
       for {
         _ <- path.setPosixPermissions(
           PosixPermissions.fromString("-w--w--w-").get
@@ -307,7 +307,7 @@ object FileOsSpec extends SimpleIOSuite with Checkers {
 
   // Warning: Platform dependent test; this may fail on some operating systems
   test("The permissions POSIX API should approve or prevent executing") {
-    tempFile { path =>
+    withTempFile { path =>
       for {
         _ <- path.setPosixPermissions(
           PosixPermissions.fromString("--x--x--x").get
@@ -334,7 +334,7 @@ object FileOsSpec extends SimpleIOSuite with Checkers {
       cats.Show.show(_.toString)
 
     forall(permissionsGenerator) { permissions =>
-      tempFile { path =>
+      withTempFile { path =>
         for {
           _     <- path.setPosixPermissions(permissions)
           perms <- path.getPosixPermissions

--- a/core/src/test/scala/io/chrisdavenport/shellfish/FileOsSpec.scala
+++ b/core/src/test/scala/io/chrisdavenport/shellfish/FileOsSpec.scala
@@ -253,7 +253,6 @@ object FileOsSpec extends SimpleIOSuite with Checkers {
     forall(pathsGenerator) { path =>
       tempFile { file =>
         tempDirectory { dir =>
-
           val link = dir / path / "link"
           for {
             _           <- (dir / path).createDirectories

--- a/core/src/test/scala/io/chrisdavenport/shellfish/SyntaxSpec.scala
+++ b/core/src/test/scala/io/chrisdavenport/shellfish/SyntaxSpec.scala
@@ -34,7 +34,7 @@ object SyntaxSpec extends SimpleIOSuite with Checkers {
     "Extension methods for read, write and append should work the same as the normal ones"
   ) {
     forall(Gen.asciiStr) { contents =>
-      tempFile.use { path =>
+      tempFile { path =>
         for {
           _  <- path.write(contents)
           _  <- path.append("Hi from the test!")
@@ -50,7 +50,7 @@ object SyntaxSpec extends SimpleIOSuite with Checkers {
   test(
     "Extension methods for creating and deleting a file should work the same as the normal ones"
   ) {
-    tempDirectory.use { dir =>
+    tempDirectory { dir =>
       val path = dir / "sample.txt"
       for {
         _        <- path.createFile
@@ -67,7 +67,7 @@ object SyntaxSpec extends SimpleIOSuite with Checkers {
     "Extension methods for copying a file should work the same as the normal ones"
   ) {
     forall(Gen.asciiStr) { contents =>
-      tempDirectory.use { dir =>
+      tempDirectory { dir =>
         val original = dir / "sample.txt"
         val copy1    = dir / "sample-copy.txt"
         val copy2    = dir / "sample-copy-jo2.txt"
@@ -87,7 +87,7 @@ object SyntaxSpec extends SimpleIOSuite with Checkers {
   ) {
 
     forall(Gen.asciiStr) { contents =>
-      tempDirectory.use { dir =>
+      tempDirectory { dir =>
         val original = dir / "sample.txt"
         val moved    = dir / "sample-moved.txt"
         for {

--- a/core/src/test/scala/io/chrisdavenport/shellfish/SyntaxSpec.scala
+++ b/core/src/test/scala/io/chrisdavenport/shellfish/SyntaxSpec.scala
@@ -34,7 +34,7 @@ object SyntaxSpec extends SimpleIOSuite with Checkers {
     "Extension methods for read, write and append should work the same as the normal ones"
   ) {
     forall(Gen.asciiStr) { contents =>
-      tempFile { path =>
+      withTempFile { path =>
         for {
           _  <- path.write(contents)
           _  <- path.append("Hi from the test!")
@@ -50,7 +50,7 @@ object SyntaxSpec extends SimpleIOSuite with Checkers {
   test(
     "Extension methods for creating and deleting a file should work the same as the normal ones"
   ) {
-    tempDirectory { dir =>
+    withTempDirectory { dir =>
       val path = dir / "sample.txt"
       for {
         _        <- path.createFile
@@ -67,7 +67,7 @@ object SyntaxSpec extends SimpleIOSuite with Checkers {
     "Extension methods for copying a file should work the same as the normal ones"
   ) {
     forall(Gen.asciiStr) { contents =>
-      tempDirectory { dir =>
+      withTempDirectory { dir =>
         val original = dir / "sample.txt"
         val copy1    = dir / "sample-copy.txt"
         val copy2    = dir / "sample-copy-jo2.txt"
@@ -87,7 +87,7 @@ object SyntaxSpec extends SimpleIOSuite with Checkers {
   ) {
 
     forall(Gen.asciiStr) { contents =>
-      tempDirectory { dir =>
+      withTempDirectory { dir =>
         val original = dir / "sample.txt"
         val moved    = dir / "sample-moved.txt"
         for {


### PR DESCRIPTION
As @TonioGela and @armanbilge suggested, the API is bloated with difficult concepts such as `Resources` or context abstractions. 

To ensure that newcomers are not hindered in their encounter with these things, some deletion - refactoring - changing of the API was suggested to improve the experience with the library in general. 

This PR aims to open a discussion to merge some of these changes and further discuss if some more changes are required to accomplish this goal of enhancing the experience of new users.

What has been done so far: 

* Delete the `readStream` function to get rid of the `Stream` type and concepts.
* Squash the `WithCharset` method with their standalone variant (similar to [os-lib](https://github.com/com-lihaoyi/os-lib/blob/main/os/src/ReadWriteOps.scala#L228)) style.  
* Changed the signature of the `tempFile` and `tempDirectory` to not return a `Resource`.
* Refactored some tests to deal with the new API.

Whats left to discuss: 

The `As` variant of the three standalone methods was unchanged as I think we should talk before If I may get rid only of the typeclass use and instead add the codec as a dependency in the parameters, or, get rid of the methods entirely as well as with its example in the documentation. 
