### PR TITLE
Remove public val member in implicit class

### DIFF
--- a/core/src/main/scala/io/chrisdavenport/shellfish/syntax/path/package.scala
+++ b/core/src/main/scala/io/chrisdavenport/shellfish/syntax/path/package.scala
@@ -38,7 +38,7 @@ package object path {
 
   private val files = Files[IO]
 
-  implicit class FileOps(val path: Path) extends AnyVal {
+  implicit class FileOps(private val path: Path) extends AnyVal {
 
     /**
      * Reads the contents of the file at the path using UTF-8 decoding. Returns


### PR DESCRIPTION
Really quick pull request: 

It adds the `private` soft keyword to the syntax implicit class.

This is because it was possible to access the `val path: Path` on the implicit class, as we are not using proper extension methods from Scala 3, so you could do something like this:

```scala
import syntax.path.*

Path("hey/there").path
```

Which doesn't make many sense.