### PR TITLE
Site section configuration

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -48,7 +48,11 @@ lazy val examples = project
     Compile / run / fork := true
   )
 
+import Site.SiteConfig
 lazy val site = project
   .in(file("site"))
   .enablePlugins(TypelevelSitePlugin)
   .dependsOn(core.jvm)
+  .settings(
+    laikaConfig := SiteConfig.laikaConfig
+  )

--- a/project/Site.scala
+++ b/project/Site.scala
@@ -1,0 +1,26 @@
+import laika.sbt.LaikaConfig
+import laika.config.*
+
+object Site {
+
+  private object SelectionsConfig {
+
+    val apiSelections = SelectionConfig(
+      "api-style",
+      ChoiceConfig("syntax", "Syntax"),
+      ChoiceConfig("static", "Static"),
+      ChoiceConfig("fs2", "Fs2")
+    )
+
+  }
+
+  object SiteConfig {
+
+    val laikaConfig = LaikaConfig.defaults
+      .withConfigValue(
+        Selections(SelectionsConfig.apiSelections)
+      )
+
+  }
+
+}


### PR DESCRIPTION
Add three different sections choices for the two main APIs (static object calls and syntax w/ extension methods) plus a third one using plain Fs2.

The configurations are inside `project/Site.scala`, this is in case we want to make more modifications to the site without populating more the `build.sbt` file.

**Note** This PR is one of the dependencies of the other ones.