### PR TITLE
Change `readLines` behaviour when reading an empty last newline

### DIFF
--- a/core/src/main/scala/io/chrisdavenport/shellfish/FilesOs.scala
+++ b/core/src/main/scala/io/chrisdavenport/shellfish/FilesOs.scala
@@ -81,7 +81,8 @@ object FilesOs {
 
   /**
    * Reads the contents of the file at the path using UTF-8 decoding and returns
-   * it line by line as a List of Strings.
+   * it line by line as a List of Strings. It will ignore any empty characters
+   * after the last newline (similar to `wc -l`).
    *
    * @param path
    *   The path to read from

--- a/core/src/main/scala/io/chrisdavenport/shellfish/FilesOs.scala
+++ b/core/src/main/scala/io/chrisdavenport/shellfish/FilesOs.scala
@@ -89,7 +89,11 @@ object FilesOs {
    *   The file loaded in memory as a collection of lines of Strings
    */
   def readLines(path: Path): IO[List[String]] =
-    files.readUtf8Lines(path).compile.toList
+    files
+      .readUtf8Lines(path)
+      .dropLastIf(_.isEmpty)
+      .compile
+      .toList
 
   /**
    * Reads the contents of the file and deserializes its contents as `A` using

--- a/core/src/main/scala/io/chrisdavenport/shellfish/syntax/path/package.scala
+++ b/core/src/main/scala/io/chrisdavenport/shellfish/syntax/path/package.scala
@@ -75,7 +75,8 @@ package object path {
 
     /**
      * Reads the contents of the file at the path using UTF-8 decoding and
-     * returns it line by line as a List of Strings.
+     * returns it line by line as a List of Strings. It will ignore any empty
+     * characters after the last newline (similar to `wc -l`).
      *
      * @param path
      *   The path to read from

--- a/core/src/test/scala/io/chrisdavenport/shellfish/FileOsSpec.scala
+++ b/core/src/test/scala/io/chrisdavenport/shellfish/FileOsSpec.scala
@@ -351,7 +351,7 @@ object FileOsSpec extends SimpleIOSuite with Checkers {
       Gen.size.flatMap(size => Gen.listOfN(size, Gen.alphaNumStr))
 
     forall(contentGenerator) { contentsList =>
-      tempFile.use { path =>
+      withTempFile { path =>
         for {
           _       <- path.writeLines(contentsList)
           readlns <- path.readLines

--- a/core/src/test/scala/io/chrisdavenport/shellfish/FileOsSpec.scala
+++ b/core/src/test/scala/io/chrisdavenport/shellfish/FileOsSpec.scala
@@ -80,7 +80,8 @@ object FileOsSpec extends SimpleIOSuite with Checkers {
           sizeBefore <- path.readLines.map(_.size)
           _          <- path.appendLine("Im a last line!")
           sizeAfter  <- path.readLines.map(_.size)
-        } yield expect(sizeBefore + 1 == sizeAfter)
+        } yield expect(sizeBefore + 2 == sizeAfter)
+        // That is, one new line of the appendLine and, one newline character of the writeLines method
       }
     }
   }

--- a/core/src/test/scala/io/chrisdavenport/shellfish/FileOsSpec.scala
+++ b/core/src/test/scala/io/chrisdavenport/shellfish/FileOsSpec.scala
@@ -323,7 +323,7 @@ object FileOsSpec extends SimpleIOSuite with Checkers {
     }
   }
 
-  // Warning: Platform dependent test; this may fail on some operating systems
+  // Warning: Platform-dependent test; this may fail on some operating systems
   test("We should be able to get the file permissions in POSIX systems") {
 
     val permissionsGenerator: Gen[PosixPermissions] =
@@ -340,6 +340,22 @@ object FileOsSpec extends SimpleIOSuite with Checkers {
           _     <- path.setPosixPermissions(permissions)
           perms <- path.getPosixPermissions
         } yield expect(permissions == perms)
+      }
+    }
+  }
+
+  test(
+    "Writing lines should return a list with the same length when reading them"
+  ) {
+    val contentGenerator: Gen[List[String]] =
+      Gen.size.flatMap(size => Gen.listOfN(size, Gen.alphaNumStr))
+
+    forall(contentGenerator) { contentsList =>
+      tempFile.use { path =>
+        for {
+          _       <- path.writeLines(contentsList)
+          readlns <- path.readLines
+        } yield expect(contentsList.length == readlns.length)
       }
     }
   }


### PR DESCRIPTION
This PR id due to a small bug that I pointed to @lenguyenthanh and @TonioGela when creating the tutorial. 

Basically, calling `Files[IO].writeUtf8Lines(path)` will add a newline at the end of the written lines, regarding the number of elements of the collection. This will create a bug that, when using `FIles[IO].readlUtf8Lines(path)` will always add a new empty element to the compiled collection at the end.

So this PR changes the behaviour of the `readLines` method so it ignores any empty characters after the last newline, similar if you do `wc -l` on any file that has been written by the `Files#writeUtf8Lines` method. 

It introduces changes on tests, as well as in the documentation. 